### PR TITLE
feat: support all currencies of ash_money

### DIFF
--- a/lib/craftplan/types/currency.ex
+++ b/lib/craftplan/types/currency.ex
@@ -1,42 +1,5 @@
 defmodule Craftplan.Types.Currency do
   @moduledoc false
   use Ash.Type.Enum,
-    values: [
-      :USD,
-      :EUR,
-      :JPY,
-      :GBP,
-      :CNY,
-      :AUD,
-      :CAD,
-      :CHF,
-      :HKD,
-      :SGD,
-      :SEK,
-      :KRW,
-      :NOK,
-      :NZD,
-      :INR,
-      :MXN,
-      :TWD,
-      :ZAR,
-      :BRL,
-      :DKK,
-      :PLN,
-      :THB,
-      :ILS,
-      :IDR,
-      :CZK,
-      :AED,
-      :TRY,
-      :HUF,
-      :CLP,
-      :SAR,
-      :PHP,
-      :MYR,
-      :COP,
-      :RUB,
-      :RON,
-      :PEN
-    ]
+      values: Money.Currency.known_current_currencies()
 end


### PR DESCRIPTION
this will add support for all the currencies supported by ash_money including custom currencies.
```
config :money,
  custom_currencies: [
    BTC: %{name: "Bitcoin", symbol: "₿", exponent: 8},
    GCS: %{name: "Galactic Credit Standard", symbol: "gcs", exponent: 0}
  ]
```