### PR TITLE
fix(dev): add :Z to volume mounts for SELinux compatibility

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
-      - ./.postgres:/var/lib/postgresql/data
+      - ./.postgres:/var/lib/postgresql/data:Z
   minio:
     container_name: craftplan-minio
     image: minio/minio:latest
@@ -29,7 +29,7 @@ services:
       MINIO_ACCESS_KEY: "minio"
       MINIO_SECRET_KEY: "minio123"
     volumes:
-      - .minio:/data
+      - .minio:/data:Z
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
PostgreSQL and Minio containers fail to start on SELinux-enabled hosts (Fedora Silverblue, Bluefin, RHEL, etc.) due to permission denied errors on bind-mounted volumes.

Added \`:Z\` flags to the two affected mount points in \`docker-compose.dev.yml\` so they get automatically relabeled.

Tested on Bluefin with Podman. Cheers!