### PR TITLE
feat(nutrition): standardize EU nutrition declarations

### DIFF
--- a/lib/craftplan/catalog/product.ex
+++ b/lib/craftplan/catalog/product.ex
@@ -54,7 +54,9 @@ defmodule Craftplan.Catalog.Product do
         :photos,
         :featured_photo,
         :selling_availability,
-        :max_daily_quantity
+        :max_daily_quantity,
+        :nutrition_output_quantity,
+        :nutrition_output_unit
       ],
       update: [
         :name,
@@ -64,7 +66,9 @@ defmodule Craftplan.Catalog.Product do
         :photos,
         :featured_photo,
         :selling_availability,
-        :max_daily_quantity
+        :max_daily_quantity,
+        :nutrition_output_quantity,
+        :nutrition_output_unit
       ]
     ]
 
@@ -168,6 +172,17 @@ defmodule Craftplan.Catalog.Product do
       default 0
       constraints min: 0
       description "Optional per-product capacity per day (0 = unlimited)"
+    end
+
+    attribute :nutrition_output_quantity, :decimal do
+      public? true
+      constraints min: 0
+      description "Finished product quantity used to express nutrition per 100g or 100ml."
+    end
+
+    attribute :nutrition_output_unit, :unit do
+      public? true
+      description "Finished product unit used to express nutrition per 100g or 100ml."
     end
 
     timestamps()

--- a/lib/craftplan/catalog/product/calculations/nutritional_facts.ex
+++ b/lib/craftplan/catalog/product/calculations/nutritional_facts.ex
@@ -5,6 +5,8 @@ defmodule Craftplan.Catalog.Product.Calculations.NutritionalFacts do
   use Ash.Resource.Calculation
 
   alias Craftplan.DecimalHelpers
+  alias Craftplan.Inventory.Nutrition
+  alias Decimal, as: D
 
   @impl true
   def init(_opts), do: {:ok, []}
@@ -12,15 +14,26 @@ defmodule Craftplan.Catalog.Product.Calculations.NutritionalFacts do
   @impl true
   def load(_query, _opts, _context) do
     [
+      :nutrition_output_quantity,
+      :nutrition_output_unit,
       active_bom: [
         components: [
           :component_type,
           :quantity,
           material: [
+            :unit,
             material_nutritional_facts: [
               :amount,
               :unit,
-              nutritional_fact: [:name]
+              :basis_quantity,
+              :basis_unit,
+              nutritional_fact: [
+                :key,
+                :name,
+                :parent_key,
+                :sort_order,
+                :eu_required
+              ]
             ]
           ]
         ]
@@ -36,12 +49,13 @@ defmodule Craftplan.Catalog.Product.Calculations.NutritionalFacts do
   defp calculate_nutritional_facts(%{active_bom: %Ash.NotLoaded{}}), do: []
   defp calculate_nutritional_facts(%{active_bom: nil}), do: []
 
-  defp calculate_nutritional_facts(%{active_bom: bom}) do
+  defp calculate_nutritional_facts(%{active_bom: bom} = product) do
     bom.components
     |> Enum.filter(&(&1.component_type == :material))
     |> extract_nutritional_facts()
     |> group_and_sum_facts()
-    |> Enum.sort_by(& &1.name)
+    |> scale_to_declaration_basis(product)
+    |> Enum.sort_by(&{&1.sort_order || 1000, &1.name})
   end
 
   defp extract_nutritional_facts(components) do
@@ -49,11 +63,18 @@ defmodule Craftplan.Catalog.Product.Calculations.NutritionalFacts do
       Enum.map(component.material.material_nutritional_facts, fn fact ->
         qty = DecimalHelpers.to_decimal(component.quantity)
         amt = DecimalHelpers.to_decimal(fact.amount)
+        basis = positive_decimal(fact.basis_quantity, D.new(100))
 
         %{
+          key: fact.nutritional_fact.key || fact.nutritional_fact.name,
           name: fact.nutritional_fact.name,
-          amount: Decimal.mult(amt, qty),
-          unit: fact.unit
+          amount: D.div(D.mult(amt, qty), basis),
+          unit: fact.unit,
+          parent_key: fact.nutritional_fact.parent_key,
+          sort_order: fact.nutritional_fact.sort_order || 1000,
+          eu_required: fact.nutritional_fact.eu_required || false,
+          basis_unit: fact.basis_unit,
+          material_unit: component.material.unit
         }
       end)
     end)
@@ -61,18 +82,60 @@ defmodule Craftplan.Catalog.Product.Calculations.NutritionalFacts do
 
   defp group_and_sum_facts(facts) do
     facts
-    |> Enum.group_by(& &1.name)
-    |> Enum.map(fn {name, grouped_facts} ->
+    |> Enum.group_by(& &1.key)
+    |> Enum.map(fn {_key, grouped_facts} ->
+      first = List.first(grouped_facts)
       total_amount = sum_amounts(grouped_facts)
-      unit = List.first(grouped_facts).unit
 
-      %{name: name, amount: total_amount, unit: unit}
+      %{
+        key: first.key,
+        name: first.name,
+        amount: total_amount,
+        unit: first.unit,
+        parent_key: first.parent_key,
+        sort_order: first.sort_order,
+        eu_required: first.eu_required,
+        per_quantity: nil,
+        per_unit: nil,
+        declaration?: false
+      }
     end)
   end
 
+  defp scale_to_declaration_basis(facts, product) do
+    output_quantity = Map.get(product, :nutrition_output_quantity)
+    output_unit = Map.get(product, :nutrition_output_unit)
+
+    if Nutrition.declaration_output?(output_quantity, output_unit) do
+      scale = D.div(D.new(100), DecimalHelpers.to_decimal(output_quantity))
+
+      Enum.map(facts, fn fact ->
+        %{
+          fact
+          | amount: D.mult(fact.amount, scale),
+            per_quantity: D.new(100),
+            per_unit: output_unit,
+            declaration?: true
+        }
+      end)
+    else
+      facts
+    end
+  end
+
   defp sum_amounts(facts) do
-    Enum.reduce(facts, Decimal.new(0), fn fact, acc ->
-      Decimal.add(acc, fact.amount)
+    Enum.reduce(facts, D.new(0), fn fact, acc ->
+      D.add(acc, fact.amount)
     end)
+  end
+
+  defp positive_decimal(value, fallback) do
+    value = DecimalHelpers.to_decimal(value)
+
+    if D.compare(value, D.new(0)) == :gt do
+      value
+    else
+      fallback
+    end
   end
 end

--- a/lib/craftplan/inventory/changes/protect_system_nutritional_fact.ex
+++ b/lib/craftplan/inventory/changes/protect_system_nutritional_fact.ex
@@ -1,0 +1,19 @@
+defmodule Craftplan.Inventory.Changes.ProtectSystemNutritionalFact do
+  @moduledoc false
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    if Map.get(changeset.data, :system) do
+      Changeset.add_error(changeset,
+        field: :system,
+        message: "system nutritional facts cannot be deleted"
+      )
+    else
+      changeset
+    end
+  end
+end

--- a/lib/craftplan/inventory/changes/set_nutritional_fact_metadata.ex
+++ b/lib/craftplan/inventory/changes/set_nutritional_fact_metadata.ex
@@ -1,0 +1,62 @@
+defmodule Craftplan.Inventory.Changes.SetNutritionalFactMetadata do
+  @moduledoc false
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+  alias Craftplan.Inventory.Nutrition
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    key = present_value(changeset, :key)
+    name = present_value(changeset, :name)
+
+    key =
+      cond do
+        present?(key) ->
+          key
+
+        present?(name) ->
+          Nutrition.standard_key_for_name(name) || Nutrition.custom_key(name)
+
+        true ->
+          key
+      end
+
+    changeset =
+      if present?(key) do
+        Changeset.force_change_attribute(changeset, :key, key)
+      else
+        changeset
+      end
+
+    case Nutrition.standard_fact(key) do
+      nil ->
+        changeset
+        |> maybe_set(:eu_required, false)
+        |> maybe_set(:system, false)
+
+      fact ->
+        changeset
+        |> Changeset.force_change_attribute(:name, fact.name)
+        |> Changeset.force_change_attribute(:default_unit, fact.default_unit)
+        |> Changeset.force_change_attribute(:parent_key, fact.parent_key)
+        |> Changeset.force_change_attribute(:sort_order, fact.sort_order)
+        |> Changeset.force_change_attribute(:eu_required, fact.eu_required)
+        |> Changeset.force_change_attribute(:system, fact.system)
+    end
+  end
+
+  defp present_value(changeset, field) do
+    Changeset.get_attribute(changeset, field) || Map.get(changeset.data, field)
+  end
+
+  defp maybe_set(changeset, field, value) do
+    case present_value(changeset, field) do
+      nil -> Changeset.force_change_attribute(changeset, field, value)
+      _ -> changeset
+    end
+  end
+
+  defp present?(value), do: not is_nil(value) and String.trim(to_string(value)) != ""
+end

--- a/lib/craftplan/inventory/changes/validate_material_nutrition.ex
+++ b/lib/craftplan/inventory/changes/validate_material_nutrition.ex
@@ -1,0 +1,152 @@
+defmodule Craftplan.Inventory.Changes.ValidateMaterialNutrition do
+  @moduledoc false
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+  alias Ash.Query
+  alias Craftplan.Inventory.NutritionalFact
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    entries =
+      changeset
+      |> Changeset.get_argument(:material_nutritional_facts)
+      |> normalize_entries()
+
+    facts_by_id = facts_by_id(entries)
+
+    changeset
+    |> validate_entry_amounts(entries)
+    |> validate_child_not_greater(entries, facts_by_id, "saturates", "fat")
+    |> validate_child_not_greater(entries, facts_by_id, "sugars", "carbohydrate")
+  end
+
+  defp normalize_entries(nil), do: []
+
+  defp normalize_entries(entries) when is_map(entries) do
+    entries
+    |> Map.values()
+    |> normalize_entries()
+  end
+
+  defp normalize_entries(entries) when is_list(entries), do: entries
+  defp normalize_entries(_entries), do: []
+
+  defp facts_by_id(entries) do
+    ids =
+      entries
+      |> Enum.map(&field(&1, :nutritional_fact_id))
+      |> Enum.filter(&present?/1)
+      |> Enum.uniq()
+
+    case ids do
+      [] ->
+        %{}
+
+      _ ->
+        NutritionalFact
+        |> Query.filter(id in ^ids)
+        |> Ash.read!(authorize?: false)
+        |> Map.new(&{&1.id, &1})
+    end
+  rescue
+    _ -> %{}
+  end
+
+  defp validate_entry_amounts(changeset, entries) do
+    Enum.reduce(entries, changeset, fn entry, changeset ->
+      changeset
+      |> validate_non_negative(entry, :amount)
+      |> validate_positive(entry, :basis_quantity)
+    end)
+  end
+
+  defp validate_non_negative(changeset, entry, field_name) do
+    case decimal(field(entry, field_name)) do
+      nil ->
+        changeset
+
+      value ->
+        if Decimal.compare(value, Decimal.new(0)) == :lt do
+          Changeset.add_error(changeset,
+            field: :material_nutritional_facts,
+            message: "#{field_name} must be greater than or equal to zero"
+          )
+        else
+          changeset
+        end
+    end
+  end
+
+  defp validate_positive(changeset, entry, field_name) do
+    case decimal(field(entry, field_name)) do
+      nil ->
+        changeset
+
+      value ->
+        if Decimal.compare(value, Decimal.new(0)) == :gt do
+          changeset
+        else
+          Changeset.add_error(changeset,
+            field: :material_nutritional_facts,
+            message: "#{field_name} must be greater than zero"
+          )
+        end
+    end
+  end
+
+  defp validate_child_not_greater(changeset, entries, facts_by_id, child_key, parent_key) do
+    entries_by_key =
+      entries
+      |> Enum.group_by(fn entry -> fact_key(entry, facts_by_id) end)
+      |> Map.new(fn {key, grouped} -> {key, List.first(grouped)} end)
+
+    child = Map.get(entries_by_key, child_key)
+    parent = Map.get(entries_by_key, parent_key)
+
+    with true <- not is_nil(child),
+         true <- not is_nil(parent),
+         child_amount when not is_nil(child_amount) <- decimal(field(child, :amount)),
+         parent_amount when not is_nil(parent_amount) <- decimal(field(parent, :amount)),
+         :gt <- Decimal.compare(child_amount, parent_amount) do
+      Changeset.add_error(changeset,
+        field: :material_nutritional_facts,
+        message: "#{child_key} cannot exceed #{parent_key}"
+      )
+    else
+      _ -> changeset
+    end
+  end
+
+  defp fact_key(entry, facts_by_id) do
+    fact =
+      entry
+      |> field(:nutritional_fact_id)
+      |> then(fn id -> Map.get(facts_by_id, id) end)
+
+    case fact do
+      %{key: key} -> key
+      _ -> nil
+    end
+  end
+
+  defp field(entry, name) when is_map(entry) do
+    Map.get(entry, name) || Map.get(entry, Atom.to_string(name))
+  end
+
+  defp field(_entry, _name), do: nil
+
+  defp decimal(nil), do: nil
+  defp decimal(""), do: nil
+
+  defp decimal(%Decimal{} = value), do: value
+
+  defp decimal(value) do
+    Decimal.new(to_string(value))
+  rescue
+    _ -> nil
+  end
+
+  defp present?(value), do: not is_nil(value) and String.trim(to_string(value)) != ""
+end

--- a/lib/craftplan/inventory/material.ex
+++ b/lib/craftplan/inventory/material.ex
@@ -84,6 +84,7 @@ defmodule Craftplan.Inventory.Material do
 
       argument :material_nutritional_facts, {:array, :map}
 
+      change Craftplan.Inventory.Changes.ValidateMaterialNutrition
       change manage_relationship(:material_nutritional_facts, type: :direct_control)
     end
 

--- a/lib/craftplan/inventory/material_nutritional_fact.ex
+++ b/lib/craftplan/inventory/material_nutritional_fact.ex
@@ -16,7 +16,7 @@ defmodule Craftplan.Inventory.MaterialNutritionalFact do
 
     create :create do
       primary? true
-      accept [:nutritional_fact_id, :material_id, :amount, :unit]
+      accept [:nutritional_fact_id, :material_id, :amount, :unit, :basis_quantity, :basis_unit]
     end
   end
 
@@ -35,11 +35,24 @@ defmodule Craftplan.Inventory.MaterialNutritionalFact do
     attribute :amount, :decimal do
       public? true
       allow_nil? false
+      constraints min: 0
     end
 
     attribute :unit, :unit do
       public? true
       allow_nil? false
+    end
+
+    attribute :basis_quantity, :decimal do
+      public? true
+      allow_nil? false
+      default Decimal.new(100)
+    end
+
+    attribute :basis_unit, :unit do
+      public? true
+      allow_nil? false
+      default :gram
     end
   end
 

--- a/lib/craftplan/inventory/nutrition.ex
+++ b/lib/craftplan/inventory/nutrition.ex
@@ -1,0 +1,146 @@
+defmodule Craftplan.Inventory.Nutrition do
+  @moduledoc false
+
+  @standard_facts [
+    %{
+      key: "energy_kj",
+      name: "Energy (kJ)",
+      default_unit: :kilojoule,
+      parent_key: nil,
+      sort_order: 10,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "energy_kcal",
+      name: "Energy (kcal)",
+      default_unit: :kcal,
+      parent_key: nil,
+      sort_order: 20,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "fat",
+      name: "Fat",
+      default_unit: :gram,
+      parent_key: nil,
+      sort_order: 30,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "saturates",
+      name: "Saturates",
+      default_unit: :gram,
+      parent_key: "fat",
+      sort_order: 40,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "carbohydrate",
+      name: "Carbohydrate",
+      default_unit: :gram,
+      parent_key: nil,
+      sort_order: 50,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "sugars",
+      name: "Sugars",
+      default_unit: :gram,
+      parent_key: "carbohydrate",
+      sort_order: 60,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "protein",
+      name: "Protein",
+      default_unit: :gram,
+      parent_key: nil,
+      sort_order: 70,
+      eu_required: true,
+      system: true
+    },
+    %{
+      key: "salt",
+      name: "Salt",
+      default_unit: :gram,
+      parent_key: nil,
+      sort_order: 80,
+      eu_required: true,
+      system: true
+    }
+  ]
+
+  @facts_by_key Map.new(@standard_facts, &{&1.key, &1})
+
+  @legacy_names %{
+    "energy (kj)" => "energy_kj",
+    "energy kj" => "energy_kj",
+    "kilojoules" => "energy_kj",
+    "kj" => "energy_kj",
+    "energy" => "energy_kcal",
+    "energy (kcal)" => "energy_kcal",
+    "energy kcal" => "energy_kcal",
+    "calories" => "energy_kcal",
+    "kcal" => "energy_kcal",
+    "fat" => "fat",
+    "saturated fat" => "saturates",
+    "saturates" => "saturates",
+    "carbohydrate" => "carbohydrate",
+    "carbohydrates" => "carbohydrate",
+    "sugar" => "sugars",
+    "sugars" => "sugars",
+    "protein" => "protein",
+    "salt" => "salt"
+  }
+
+  def standard_facts, do: @standard_facts
+
+  def standard_keys, do: Map.keys(@facts_by_key)
+
+  def standard_fact(key) when is_binary(key), do: Map.get(@facts_by_key, key)
+  def standard_fact(_key), do: nil
+
+  def standard_key_for_name(name) when is_binary(name) do
+    @legacy_names[normalize_name(name)]
+  end
+
+  def standard_key_for_name(_name), do: nil
+
+  def custom_key(name) do
+    normalized =
+      name
+      |> to_string()
+      |> String.downcase()
+      |> String.replace(~r/[^\p{L}\p{N}]+/u, "_")
+      |> String.trim("_")
+
+    case normalized do
+      "" -> "custom:fact"
+      value -> "custom:" <> value
+    end
+  end
+
+  def declaration_output?(quantity, unit) do
+    quantity = decimal(quantity)
+
+    not is_nil(quantity) and Decimal.compare(quantity, Decimal.new(0)) == :gt and
+      unit in [:gram, :milliliter]
+  end
+
+  defp normalize_name(name) do
+    name
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace(~r/\s+/, " ")
+  end
+
+  defp decimal(nil), do: nil
+  defp decimal(%Decimal{} = value), do: value
+  defp decimal(value), do: Decimal.new(to_string(value))
+end

--- a/lib/craftplan/inventory/nutritional_fact.ex
+++ b/lib/craftplan/inventory/nutritional_fact.ex
@@ -6,16 +6,58 @@ defmodule Craftplan.Inventory.NutritionalFact do
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer]
 
+  alias Craftplan.Inventory.Changes.SetNutritionalFactMetadata
+
   postgres do
     table "inventory_nutritional_facts"
     repo Craftplan.Repo
   end
 
   actions do
-    defaults [:read, :destroy, create: [:name], update: [:name]]
+    defaults [:read]
+
+    create :create do
+      primary? true
+
+      accept [
+        :name,
+        :key,
+        :default_unit,
+        :parent_key,
+        :sort_order,
+        :eu_required,
+        :system
+      ]
+
+      change SetNutritionalFactMetadata
+    end
+
+    update :update do
+      primary? true
+      require_atomic? false
+
+      accept [
+        :name,
+        :key,
+        :default_unit,
+        :parent_key,
+        :sort_order,
+        :eu_required,
+        :system
+      ]
+
+      change SetNutritionalFactMetadata
+    end
+
+    destroy :destroy do
+      primary? true
+      require_atomic? false
+
+      change Craftplan.Inventory.Changes.ProtectSystemNutritionalFact
+    end
 
     read :list do
-      prepare build(sort: :name)
+      prepare build(sort: [:sort_order, :name])
 
       pagination do
         required? false
@@ -26,7 +68,7 @@ defmodule Craftplan.Inventory.NutritionalFact do
     end
 
     read :keyset do
-      prepare build(sort: :name)
+      prepare build(sort: [:sort_order, :name])
       pagination keyset?: true
     end
   end
@@ -48,13 +90,49 @@ defmodule Craftplan.Inventory.NutritionalFact do
     attribute :name, :string do
       public? true
       allow_nil? false
-      constraints min_length: 1, match: ~r/^[\p{L}\p{N}\w\s\-\.・（）「」]+$/u
+      constraints min_length: 1, match: ~r/^[\p{L}\p{N}\w\s\-\.\(\)・（）「」]+$/u
+    end
+
+    attribute :key, :string do
+      public? true
+      allow_nil? false
+      constraints min_length: 1, match: ~r/^[\p{L}\p{N}_:\-]+$/u
+    end
+
+    attribute :default_unit, :unit do
+      public? true
+      allow_nil? false
+      default :gram
+    end
+
+    attribute :parent_key, :string do
+      public? true
+    end
+
+    attribute :sort_order, :integer do
+      public? true
+      allow_nil? false
+      default 1000
+      constraints min: 0
+    end
+
+    attribute :eu_required, :boolean do
+      public? true
+      allow_nil? false
+      default false
+    end
+
+    attribute :system, :boolean do
+      public? true
+      allow_nil? false
+      default false
     end
 
     timestamps()
   end
 
   identities do
+    identity :key, [:key]
     identity :name, [:name]
   end
 end

--- a/lib/craftplan/types/unit.ex
+++ b/lib/craftplan/types/unit.ex
@@ -1,9 +1,9 @@
 defmodule Craftplan.Types.Unit do
   @moduledoc """
   Represents measurement units with conversion and formatting capabilities.
-  Supports gram, milliliter, piece, kcal, milligram, and percent units with appropriate abbreviations.
+  Supports gram, milliliter, piece, kcal, kilojoule, milligram, and percent units with appropriate abbreviations.
   """
-  use Ash.Type.Enum, values: [:gram, :milliliter, :piece, :kcal, :milligram, :percent]
+  use Ash.Type.Enum, values: [:gram, :milliliter, :piece, :kcal, :kilojoule, :milligram, :percent]
 
   @unit_abbreviations %{
     kilogram: "kg",
@@ -12,6 +12,7 @@ defmodule Craftplan.Types.Unit do
     milliliter: "ml",
     piece: "pc",
     kcal: "kcal",
+    kilojoule: "kJ",
     milligram: "mg",
     percent: "%"
   }
@@ -21,6 +22,7 @@ defmodule Craftplan.Types.Unit do
     milliliter: "milliliter",
     piece: "piece",
     kcal: "kcal",
+    kilojoule: "kJ",
     milligram: "mg",
     percent: "%"
   }
@@ -30,6 +32,7 @@ defmodule Craftplan.Types.Unit do
     milliliter: "milliliters",
     piece: "pieces",
     kcal: "kcal",
+    kilojoule: "kJ",
     milligram: "mg",
     percent: "%"
   }
@@ -109,6 +112,11 @@ defmodule Craftplan.Types.Unit do
   def abbreviation(:kcal, value) when is_integer(value), do: "#{value} #{@unit_abbreviations.kcal}"
 
   def abbreviation(:kcal, value), do: "#{format_number(value)} #{@unit_abbreviations.kcal}"
+
+  # Kilojoules - no conversion needed, always displays as kJ
+  def abbreviation(:kilojoule, value) when is_integer(value), do: "#{value} #{@unit_abbreviations.kilojoule}"
+
+  def abbreviation(:kilojoule, value), do: "#{format_number(value)} #{@unit_abbreviations.kilojoule}"
 
   # Milligram - no automatic conversion to avoid confusion with gram conversions
   def abbreviation(:milligram, value) when is_integer(value), do: "#{value} #{@unit_abbreviations.milligram}"

--- a/lib/craftplan_web/live/manage/inventory_live/form_component_nutritional_facts.ex
+++ b/lib/craftplan_web/live/manage/inventory_live/form_component_nutritional_facts.ex
@@ -27,11 +27,11 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
           <div id="nutritional-facts-list">
             <div
               id="nutritional-facts"
-              class="mt-2 grid w-full grid-cols-4 gap-x-4 text-sm leading-6 text-stone-700"
+              class="mt-2 grid w-full grid-cols-5 gap-x-4 text-sm leading-6 text-stone-700"
             >
               <div
                 role="row"
-                class="col-span-4 grid grid-cols-4 border-b border-stone-300 text-left text-sm leading-6 text-stone-500"
+                class="col-span-5 grid grid-cols-5 border-b border-stone-300 text-left text-sm leading-6 text-stone-500"
               >
                 <div class="border-r border-stone-200 p-0 pr-6 pb-4 font-normal last:border-r-0 ">
                   Fact
@@ -43,18 +43,22 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
                   Unit
                 </div>
                 <div class="border-r border-stone-200 p-0 pr-6 pb-4 pl-4 font-normal last:border-r-0">
+                  Per
+                </div>
+                <div class="border-r border-stone-200 p-0 pr-6 pb-4 pl-4 font-normal last:border-r-0">
                   <span class="opacity-0">Actions</span>
                 </div>
               </div>
 
-              <div role="row" class="col-span-4 hidden py-4 text-stone-400 last:block">
+              <div role="row" class="col-span-5 hidden py-4 text-stone-400 last:block">
                 <div>
                   No nutritional facts
                 </div>
               </div>
 
               <.inputs_for :let={fact_form} field={@form[:material_nutritional_facts]}>
-                <div role="row" class="group col-span-4 grid grid-cols-4 hover:bg-stone-200/40">
+                <% fact = fact_for_form(@nutritional_facts_map, fact_form) %>
+                <div role="row" class="group col-span-5 grid grid-cols-5 hover:bg-stone-200/40">
                   <div class="relative border-r border-b border-stone-200 p-0 last:border-r-0 ">
                     <div class="block py-4 pr-6">
                       <span class="relative -mt-2">
@@ -88,17 +92,43 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
                   <div class="relative border-r border-b border-stone-200 p-0 pl-4 last:border-r-0">
                     <div class="block py-4 pr-6">
                       <span class="relative -mt-2">
+                        <%= if fixed_unit_fact?(fact) do %>
+                          <input
+                            type="hidden"
+                            name={fact_form[:unit].name}
+                            value={fact.default_unit}
+                          />
+                          <span class="block py-2 text-stone-700">
+                            {unit_label(fact.default_unit)}
+                          </span>
+                        <% else %>
+                          <.input
+                            field={fact_form[:unit]}
+                            type="select"
+                            options={nutrition_unit_options()}
+                            flat={true}
+                          />
+                        <% end %>
+                      </span>
+                    </div>
+                  </div>
+
+                  <div class="relative border-r border-b border-stone-200 p-0 pl-4 last:border-r-0">
+                    <div class="block py-4 pr-6">
+                      <span class="relative -mt-2 grid grid-cols-2 gap-2">
+                        <div class="border-b border-dashed border-stone-300">
+                          <.input
+                            field={fact_form[:basis_quantity]}
+                            type="number"
+                            step="0.01"
+                            min="0.01"
+                            flat={true}
+                          />
+                        </div>
                         <.input
-                          field={fact_form[:unit]}
+                          field={fact_form[:basis_unit]}
                           type="select"
-                          options={[
-                            {"Kilocalories (kcal)", :kcal},
-                            {"Gram (g)", :gram},
-                            {"Milligram (mg)", :milligram},
-                            {"Milliliter (ml)", :milliliter},
-                            {"Percent (%)", :percent},
-                            {"Piece", :piece}
-                          ]}
+                          options={basis_unit_options()}
                           flat={true}
                         />
                       </span>
@@ -123,7 +153,7 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
                 </div>
               </.inputs_for>
 
-              <div role="row" class="col-span-4 py-4">
+              <div role="row" class="col-span-5 py-4">
                 <button
                   type="button"
                   phx-click="show_add_modal"
@@ -199,15 +229,20 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
           "nutritional_fact_id" => fact.nutritional_fact_id,
           "material_id" => fact.material_id,
           "amount" => fact.amount,
-          "unit" => fact.unit
+          "unit" => fact.unit,
+          "basis_quantity" => fact.basis_quantity || Decimal.new(100),
+          "basis_unit" => fact.basis_unit || default_basis_unit(material.unit)
         }
       end)
+
+    nutritional_facts_map = Map.new(assigns.nutritional_facts, &{&1.id, &1})
 
     {:ok,
      socket
      |> assign(assigns)
      |> assign(:form, form)
      |> assign(:existing_facts, existing_facts)
+     |> assign(:nutritional_facts_map, nutritional_facts_map)
      |> assign(:show_modal, false)}
   end
 
@@ -257,13 +292,17 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
           socket.assigns.existing_facts || []
       end
 
+    fact = Map.get(socket.assigns.nutritional_facts_map, fact_id)
+    default_unit = (fact && fact.default_unit) || :gram
+
     # Create the new fact to add
     new_fact = %{
       "nutritional_fact_id" => fact_id,
       "material_id" => socket.assigns.material.id,
       "amount" => "0",
-      # Default unit
-      "unit" => "gram"
+      "unit" => Atom.to_string(default_unit),
+      "basis_quantity" => "100",
+      "basis_unit" => Atom.to_string(default_basis_unit(socket.assigns.material.unit))
     }
 
     # Combine existing facts with the new fact
@@ -332,11 +371,13 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
     |> to_form()
   end
 
-  # Returns all nutritional fact options
   defp nutritional_fact_options(facts) do
     facts
     |> Enum.map(fn fact -> {fact.name, fact.id} end)
-    |> Enum.sort_by(fn {name, _id} -> name end)
+    |> Enum.sort_by(fn {name, id} ->
+      fact = Enum.find(facts, &(&1.id == id))
+      {fact.sort_order || 1000, name}
+    end)
   end
 
   # Returns only nutritional facts that haven't been added yet
@@ -371,6 +412,53 @@ defmodule CraftplanWeb.InventoryLive.FormComponentNutritionalFacts do
     # Return options for available facts
     available_facts
     |> Enum.map(fn fact -> {fact.name, fact.id} end)
-    |> Enum.sort_by(fn {name, _id} -> name end)
+    |> Enum.sort_by(fn {name, id} ->
+      fact = Enum.find(available_facts, &(&1.id == id))
+      {fact.sort_order || 1000, name}
+    end)
   end
+
+  defp fact_for_form(facts_map, fact_form) do
+    Map.get(facts_map, fact_form[:nutritional_fact_id].value)
+  end
+
+  defp fixed_unit_fact?(%{system: true}), do: true
+  defp fixed_unit_fact?(_fact), do: false
+
+  defp nutrition_unit_options do
+    [
+      {"Kilojoules (kJ)", :kilojoule},
+      {"Kilocalories (kcal)", :kcal},
+      {"Gram (g)", :gram},
+      {"Milligram (mg)", :milligram},
+      {"Milliliter (ml)", :milliliter},
+      {"Percent (%)", :percent},
+      {"Piece", :piece}
+    ]
+  end
+
+  defp basis_unit_options do
+    [
+      {"Gram (g)", :gram},
+      {"Milliliter (ml)", :milliliter},
+      {"Piece", :piece}
+    ]
+  end
+
+  defp unit_label(unit) do
+    nutrition_unit_options()
+    |> Enum.find(fn {_label, value} ->
+      value == unit || Atom.to_string(value) == to_string(unit)
+    end)
+    |> case do
+      {label, _value} -> label
+      _ -> to_string(unit)
+    end
+  end
+
+  defp default_basis_unit(:milliliter), do: :milliliter
+  defp default_basis_unit("milliliter"), do: :milliliter
+  defp default_basis_unit(:piece), do: :piece
+  defp default_basis_unit("piece"), do: :piece
+  defp default_basis_unit(_unit), do: :gram
 end

--- a/lib/craftplan_web/live/manage/inventory_live/show.ex
+++ b/lib/craftplan_web/live/manage/inventory_live/show.ex
@@ -49,7 +49,7 @@ defmodule CraftplanWeb.InventoryLive.Show do
             <div class="flex-inline items-center space-x-1">
               <.badge
                 :for={fact <- @material.material_nutritional_facts}
-                text={"#{fact.nutritional_fact.name}: #{fact.amount} #{fact.unit}"}
+                text={"#{fact.nutritional_fact.name}: #{fact.amount} #{fact.unit} per #{fact.basis_quantity || 100} #{fact.basis_unit || @material.unit}"}
               />
               <span :if={Enum.empty?(@material.material_nutritional_facts)}>None</span>
             </div>

--- a/lib/craftplan_web/live/manage/product_live/form_component.ex
+++ b/lib/craftplan_web/live/manage/product_live/form_component.ex
@@ -51,6 +51,22 @@ defmodule CraftplanWeb.ProductLive.FormComponent do
           label="Max units per day (0 = unlimited)"
         />
 
+        <div class="grid gap-4 sm:grid-cols-2">
+          <.input
+            field={@form[:nutrition_output_quantity]}
+            type="number"
+            min="0"
+            step="0.01"
+            label="Finished output"
+          />
+          <.input
+            field={@form[:nutrition_output_unit]}
+            type="select"
+            label="Output unit"
+            options={[{"Gram (g)", :gram}, {"Milliliter (ml)", :milliliter}]}
+          />
+        </div>
+
         <:actions>
           <.button variant={:primary} phx-disable-with="Saving...">Save Product</.button>
         </:actions>

--- a/lib/craftplan_web/live/manage/product_live/label.ex
+++ b/lib/craftplan_web/live/manage/product_live/label.ex
@@ -40,6 +40,24 @@ defmodule CraftplanWeb.ProductLive.Label do
         </div>
       </div>
 
+      <div :if={nutrition_declaration?(@nutrition_facts)} class="mb-4">
+        <div class="mb-1 text-sm font-medium text-stone-700">
+          Nutrition declaration per {nutrition_basis_label(@nutrition_facts)}
+        </div>
+        <table class="w-full border-collapse text-sm">
+          <tbody>
+            <tr :for={fact <- @nutrition_facts} class="border-b border-stone-200">
+              <td class="py-1 pr-4">
+                <span class={if Map.get(fact, :parent_key), do: "pl-4", else: ""}>
+                  {nutrient_label(fact)}
+                </span>
+              </td>
+              <td class="py-1 text-right">{format_amount(fact.unit, fact.amount)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
       <div class="mt-6 flex justify-end print:hidden">
         <.button variant={:primary} onclick="window.print()">Print</.button>
       </div>
@@ -56,6 +74,7 @@ defmodule CraftplanWeb.ProductLive.Label do
           :name,
           :sku,
           :allergens,
+          :nutritional_facts,
           active_bom: [components: [:component_type, material: [:name]]]
         ],
         actor: socket.assigns[:current_user]
@@ -101,6 +120,7 @@ defmodule CraftplanWeb.ProductLive.Label do
      socket
      |> assign(:product, product)
      |> assign(:ingredients, ingredients)
+     |> assign(:nutrition_facts, product.nutritional_facts || [])
      |> assign(
        :allergens,
        (product.allergens != [] && product.allergens) ||
@@ -119,4 +139,36 @@ defmodule CraftplanWeb.ProductLive.Label do
   end
 
   # no recipe fallback
+
+  defp nutrition_declaration?(facts), do: Enum.any?(facts, &Map.get(&1, :declaration?, false))
+
+  defp nutrition_basis_label(facts) do
+    facts
+    |> Enum.find(&Map.get(&1, :declaration?, false))
+    |> case do
+      %{per_quantity: quantity, per_unit: unit} ->
+        "#{format_basis_quantity(quantity)} #{basis_unit_abbreviation(unit)}"
+
+      _ ->
+        "100 g"
+    end
+  end
+
+  defp nutrient_label(%{parent_key: parent_key, name: name}) when not is_nil(parent_key) do
+    "of which #{String.downcase(name)}"
+  end
+
+  defp nutrient_label(%{name: name}), do: name
+
+  defp basis_unit_abbreviation(:milliliter), do: "ml"
+  defp basis_unit_abbreviation("milliliter"), do: "ml"
+  defp basis_unit_abbreviation(_unit), do: "g"
+
+  defp format_basis_quantity(%Decimal{} = quantity) do
+    quantity
+    |> Decimal.normalize()
+    |> Decimal.to_string(:normal)
+  end
+
+  defp format_basis_quantity(quantity), do: to_string(quantity)
 end

--- a/lib/craftplan_web/live/manage/product_live/show.ex
+++ b/lib/craftplan_web/live/manage/product_live/show.ex
@@ -99,6 +99,16 @@ defmodule CraftplanWeb.ProductLive.Show do
           >
             {@product.max_daily_quantity}
           </:item>
+
+          <:item
+            :if={@product.nutrition_output_quantity}
+            title="Nutrition output"
+          >
+            {format_amount(
+              @product.nutrition_output_unit || :gram,
+              @product.nutrition_output_quantity
+            )}
+          </:item>
         </.list>
       </.tabs_content>
 
@@ -119,14 +129,27 @@ defmodule CraftplanWeb.ProductLive.Show do
 
       <.tabs_content :if={@live_action == :nutrition}>
         <div>
-          <h3 class="my-4 text-lg font-medium">Nutritional Facts</h3>
-          <p class="mb-4 text-sm text-stone-500">
-            The nutritional information is automatically calculated from your recipe components.
+          <h3 class="my-4 text-lg font-medium">
+            {nutrition_heading(@product.nutritional_facts)}
+          </h3>
+          <p
+            :if={
+              @product.nutritional_facts != [] && !nutrition_declaration?(@product.nutritional_facts)
+            }
+            class="mb-4 text-sm text-stone-500"
+          >
+            Finished output is not set, so amounts are shown for one product unit.
           </p>
         </div>
         <.table id="nutritional-facts" rows={@product.nutritional_facts}>
-          <:col :let={fact} label="Nutrient">{fact.name}</:col>
-          <:col :let={fact} label="Amount">{format_amount(fact.unit, fact.amount)}</:col>
+          <:col :let={fact} label="Nutrient">
+            <span class={if Map.get(fact, :parent_key), do: "pl-4", else: ""}>
+              {nutrient_label(fact)}
+            </span>
+          </:col>
+          <:col :let={fact} label={nutrition_amount_label(@product.nutritional_facts)}>
+            {format_amount(fact.unit, fact.amount)}
+          </:col>
         </.table>
       </.tabs_content>
 
@@ -368,6 +391,50 @@ defmodule CraftplanWeb.ProductLive.Show do
   defp list_available_products do
     Catalog.list_products!(load: [:bom_unit_cost])
   end
+
+  defp nutrition_heading(facts) do
+    if nutrition_declaration?(facts), do: "Nutrition Declaration", else: "Nutritional Facts"
+  end
+
+  defp nutrition_amount_label(facts) do
+    if nutrition_declaration?(facts) do
+      "Per #{nutrition_basis_label(facts)}"
+    else
+      "Amount"
+    end
+  end
+
+  defp nutrition_basis_label(facts) do
+    facts
+    |> Enum.find(&Map.get(&1, :declaration?, false))
+    |> case do
+      %{per_quantity: quantity, per_unit: unit} ->
+        "#{format_basis_quantity(quantity)} #{basis_unit_abbreviation(unit)}"
+
+      _ ->
+        "100 g"
+    end
+  end
+
+  defp nutrition_declaration?(facts), do: Enum.any?(facts, &Map.get(&1, :declaration?, false))
+
+  defp nutrient_label(%{parent_key: parent_key, name: name}) when not is_nil(parent_key) do
+    "of which #{String.downcase(name)}"
+  end
+
+  defp nutrient_label(%{name: name}), do: name
+
+  defp basis_unit_abbreviation(:milliliter), do: "ml"
+  defp basis_unit_abbreviation("milliliter"), do: "ml"
+  defp basis_unit_abbreviation(_unit), do: "g"
+
+  defp format_basis_quantity(%Decimal{} = quantity) do
+    quantity
+    |> Decimal.normalize()
+    |> Decimal.to_string(:normal)
+  end
+
+  defp format_basis_quantity(quantity), do: to_string(quantity)
 
   # Pricing helper
   defp suggested_price(:retail, unit_cost, settings) do

--- a/lib/craftplan_web/live/manage/settings_live/nutritional_facts_component.ex
+++ b/lib/craftplan_web/live/manage/settings_live/nutritional_facts_component.ex
@@ -51,9 +51,20 @@ defmodule CraftplanWeb.SettingsLive.NutritionalFactsComponent do
                 rows={@visible_facts}
                 wrapper_class="mt-0"
               >
-                <:col :let={fact} label="Name">{fact.name}</:col>
+                <:col :let={fact} label="Name">
+                  <span class={if fact.parent_key, do: "pl-4", else: ""}>
+                    {settings_fact_name(fact)}
+                  </span>
+                </:col>
+                <:col :let={fact} label="Unit">{unit_label(fact.default_unit)}</:col>
+                <:col :let={fact} label="Type">
+                  <.badge :if={fact.eu_required} text="EU required" />
+                  <.badge :if={!fact.eu_required && fact.system} text="System" />
+                  <span :if={!fact.system} class="text-sm text-stone-500">Custom</span>
+                </:col>
                 <:action :let={fact}>
                   <.link
+                    :if={!fact.system}
                     phx-click={JS.push("delete", value: %{id: fact.id}, target: @myself)}
                     data-confirm="Are you sure you want to delete this nutritional fact? This action cannot be undone."
                   >
@@ -61,6 +72,7 @@ defmodule CraftplanWeb.SettingsLive.NutritionalFactsComponent do
                       Delete
                     </.button>
                   </.link>
+                  <span :if={fact.system} class="text-sm text-stone-400">Locked</span>
                 </:action>
                 <:empty>
                   <div class="py-6 text-center text-sm text-stone-500">
@@ -230,4 +242,26 @@ defmodule CraftplanWeb.SettingsLive.NutritionalFactsComponent do
       |> String.contains?(downcased)
     end)
   end
+
+  defp settings_fact_name(%{parent_key: parent_key, name: name}) when not is_nil(parent_key) do
+    "of which #{String.downcase(name)}"
+  end
+
+  defp settings_fact_name(%{name: name}), do: name
+
+  defp unit_label(:kilojoule), do: "kJ"
+  defp unit_label("kilojoule"), do: "kJ"
+  defp unit_label(:kcal), do: "kcal"
+  defp unit_label("kcal"), do: "kcal"
+  defp unit_label(:gram), do: "g"
+  defp unit_label("gram"), do: "g"
+  defp unit_label(:milligram), do: "mg"
+  defp unit_label("milligram"), do: "mg"
+  defp unit_label(:milliliter), do: "ml"
+  defp unit_label("milliliter"), do: "ml"
+  defp unit_label(:percent), do: "%"
+  defp unit_label("percent"), do: "%"
+  defp unit_label(:piece), do: "pc"
+  defp unit_label("piece"), do: "pc"
+  defp unit_label(unit), do: to_string(unit)
 end

--- a/priv/repo/migrations/20260623122000_standardize_nutritional_facts.exs
+++ b/priv/repo/migrations/20260623122000_standardize_nutritional_facts.exs
@@ -1,0 +1,153 @@
+defmodule Craftplan.Repo.Migrations.StandardizeNutritionalFacts do
+  use Ecto.Migration
+
+  def up do
+    alter table(:inventory_nutritional_facts) do
+      add :key, :text
+      add :default_unit, :text, null: false, default: "gram"
+      add :parent_key, :text
+      add :sort_order, :bigint, null: false, default: 1000
+      add :eu_required, :boolean, null: false, default: false
+      add :system, :boolean, null: false, default: false
+    end
+
+    set_standard_fact("energy_kj", "Energy (kJ)", "kilojoule", nil, 10, [
+      "energy (kj)",
+      "energy kj",
+      "kilojoules",
+      "kj"
+    ])
+
+    set_standard_fact("energy_kcal", "Energy (kcal)", "kcal", nil, 20, [
+      "calories",
+      "energy",
+      "energy (kcal)",
+      "energy kcal",
+      "kcal"
+    ])
+
+    set_standard_fact("fat", "Fat", "gram", nil, 30, ["fat"])
+    set_standard_fact("saturates", "Saturates", "gram", "fat", 40, ["saturated fat", "saturates"])
+
+    set_standard_fact("carbohydrate", "Carbohydrate", "gram", nil, 50, [
+      "carbohydrate",
+      "carbohydrates"
+    ])
+
+    set_standard_fact("sugars", "Sugars", "gram", "carbohydrate", 60, ["sugar", "sugars"])
+    set_standard_fact("protein", "Protein", "gram", nil, 70, ["protein"])
+    set_standard_fact("salt", "Salt", "gram", nil, 80, ["salt"])
+
+    execute("""
+    UPDATE inventory_nutritional_facts
+    SET key = 'custom:' || id::text
+    WHERE key IS NULL
+    """)
+
+    alter table(:inventory_nutritional_facts) do
+      modify :key, :text, null: false
+    end
+
+    create unique_index(:inventory_nutritional_facts, [:key],
+             name: "inventory_nutritional_facts_key_index"
+           )
+
+    insert_standard_facts()
+
+    alter table(:inventory_material_nutritional_fact) do
+      add :basis_quantity, :decimal, null: false, default: fragment("100")
+      add :basis_unit, :text, null: false, default: "gram"
+    end
+
+    alter table(:catalog_products) do
+      add :nutrition_output_quantity, :decimal
+      add :nutrition_output_unit, :text
+    end
+  end
+
+  def down do
+    alter table(:catalog_products) do
+      remove :nutrition_output_unit
+      remove :nutrition_output_quantity
+    end
+
+    alter table(:inventory_material_nutritional_fact) do
+      remove :basis_unit
+      remove :basis_quantity
+    end
+
+    drop_if_exists unique_index(:inventory_nutritional_facts, [:key],
+                     name: "inventory_nutritional_facts_key_index"
+                   )
+
+    alter table(:inventory_nutritional_facts) do
+      remove :system
+      remove :eu_required
+      remove :sort_order
+      remove :parent_key
+      remove :default_unit
+      remove :key
+    end
+  end
+
+  defp set_standard_fact(key, name, unit, parent_key, sort_order, names) do
+    quoted_names =
+      names
+      |> Enum.map(&"'#{&1}'")
+      |> Enum.join(", ")
+
+    parent_value =
+      case parent_key do
+        nil -> "NULL"
+        value -> "'#{value}'"
+      end
+
+    execute("""
+    WITH candidates AS (
+      SELECT id
+      FROM inventory_nutritional_facts
+      WHERE lower(name) IN (#{quoted_names})
+      ORDER BY
+        CASE WHEN lower(name) = lower('#{name}') THEN 0 ELSE 1 END,
+        array_position(ARRAY[#{quoted_names}]::text[], lower(name)),
+        inserted_at,
+        id
+      LIMIT 1
+    )
+    UPDATE inventory_nutritional_facts
+    SET key = '#{key}',
+        name = '#{name}',
+        default_unit = '#{unit}',
+        parent_key = #{parent_value},
+        sort_order = #{sort_order},
+        eu_required = true,
+        system = true,
+        updated_at = (now() AT TIME ZONE 'utc')
+    WHERE id IN (SELECT id FROM candidates)
+    """)
+  end
+
+  defp insert_standard_facts do
+    execute("""
+    INSERT INTO inventory_nutritional_facts
+      (id, name, key, default_unit, parent_key, sort_order, eu_required, system, inserted_at, updated_at)
+    VALUES
+      (gen_random_uuid(), 'Energy (kJ)', 'energy_kj', 'kilojoule', NULL, 10, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Energy (kcal)', 'energy_kcal', 'kcal', NULL, 20, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Fat', 'fat', 'gram', NULL, 30, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Saturates', 'saturates', 'gram', 'fat', 40, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Carbohydrate', 'carbohydrate', 'gram', NULL, 50, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Sugars', 'sugars', 'gram', 'carbohydrate', 60, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Protein', 'protein', 'gram', NULL, 70, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc')),
+      (gen_random_uuid(), 'Salt', 'salt', 'gram', NULL, 80, true, true, (now() AT TIME ZONE 'utc'), (now() AT TIME ZONE 'utc'))
+    ON CONFLICT (key) DO UPDATE SET
+      name = EXCLUDED.name,
+      default_unit = EXCLUDED.default_unit,
+      parent_key = EXCLUDED.parent_key,
+      sort_order = EXCLUDED.sort_order,
+      eu_required = EXCLUDED.eu_required,
+      system = EXCLUDED.system,
+      updated_at = EXCLUDED.updated_at
+    """)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -4,6 +4,7 @@ alias Craftplan.Accounts
 alias Craftplan.Catalog
 alias Craftplan.CRM
 alias Craftplan.Inventory
+alias Craftplan.Inventory.Nutrition
 alias Craftplan.Orders
 alias Craftplan.Repo
 alias Craftplan.Settings
@@ -46,32 +47,52 @@ end
 
 # Add a function to seed nutritional facts
 seed_nutritional_facts = fn ->
-  seed_single_nutritional_fact = fn name ->
+  seed_single_nutritional_fact = fn attrs, identity ->
     [nutritional_fact] =
       Ash.Seed.seed!(
         Inventory.NutritionalFact,
-        [%{name: name}],
-        identity: :name
+        [attrs],
+        identity: identity
       )
 
     nutritional_fact
   end
 
+  standard_facts =
+    Map.new(Nutrition.standard_facts(), fn attrs ->
+      {attrs.key, seed_single_nutritional_fact.(attrs, :key)}
+    end)
+
+  seed_custom_fact = fn name ->
+    seed_single_nutritional_fact.(
+      %{
+        name: name,
+        key: Nutrition.custom_key(name),
+        default_unit: :gram,
+        sort_order: 1000,
+        eu_required: false,
+        system: false
+      },
+      :key
+    )
+  end
+
   %{
-    calories: seed_single_nutritional_fact.("Calories"),
-    fat: seed_single_nutritional_fact.("Fat"),
-    saturated_fat: seed_single_nutritional_fact.("Saturated Fat"),
-    carbohydrates: seed_single_nutritional_fact.("Carbohydrates"),
-    sugar: seed_single_nutritional_fact.("Sugar"),
-    fiber: seed_single_nutritional_fact.("Fiber"),
-    protein: seed_single_nutritional_fact.("Protein"),
-    salt: seed_single_nutritional_fact.("Salt"),
-    sodium: seed_single_nutritional_fact.("Sodium"),
-    calcium: seed_single_nutritional_fact.("Calcium"),
-    iron: seed_single_nutritional_fact.("Iron"),
-    vitamin_a: seed_single_nutritional_fact.("Vitamin A"),
-    vitamin_c: seed_single_nutritional_fact.("Vitamin C"),
-    vitamin_d: seed_single_nutritional_fact.("Vitamin D")
+    energy_kj: standard_facts["energy_kj"],
+    calories: standard_facts["energy_kcal"],
+    fat: standard_facts["fat"],
+    saturated_fat: standard_facts["saturates"],
+    carbohydrates: standard_facts["carbohydrate"],
+    sugar: standard_facts["sugars"],
+    protein: standard_facts["protein"],
+    salt: standard_facts["salt"],
+    fiber: seed_custom_fact.("Fibre"),
+    sodium: seed_custom_fact.("Sodium"),
+    calcium: seed_custom_fact.("Calcium"),
+    iron: seed_custom_fact.("Iron"),
+    vitamin_a: seed_custom_fact.("Vitamin A"),
+    vitamin_c: seed_custom_fact.("Vitamin C"),
+    vitamin_d: seed_custom_fact.("Vitamin D")
   }
 end
 
@@ -152,11 +173,20 @@ if System.get_env("SEED_DATA") == "true" or (Code.ensure_loaded?(Mix) and Mix.en
 
   # Add a function to link materials to nutritional facts with amounts and units
   link_material_nutritional_fact = fn material, nutritional_fact, amount, unit ->
+    basis_unit =
+      case material.unit do
+        :milliliter -> :milliliter
+        :piece -> :piece
+        _ -> :gram
+      end
+
     Ash.Seed.seed!(Inventory.MaterialNutritionalFact, %{
       material_id: material.id,
       nutritional_fact_id: nutritional_fact.id,
       amount: Decimal.new(amount),
-      unit: unit
+      unit: unit,
+      basis_quantity: Decimal.new(100),
+      basis_unit: basis_unit
     })
   end
 

--- a/priv/resource_snapshots/repo/catalog_products/20260623123557.json
+++ b/priv/resource_snapshots/repo/catalog_products/20260623123557.json
@@ -1,0 +1,207 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"draft\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "status",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "price",
+      "type": "decimal"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "sku",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "[]",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "photos",
+      "type": [
+        "array",
+        "text"
+      ]
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "featured_photo",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"available\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "selling_availability",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "max_daily_quantity",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "nutrition_output_quantity",
+      "type": "decimal"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "nutrition_output_unit",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "C847AC24DF3D461D901BF2DA0A6741D05981ABB9C352854DCEFE0656D9A260ED",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "catalog_products_name_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "name"
+        }
+      ],
+      "name": "name",
+      "nils_distinct?": true,
+      "where": null
+    },
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "catalog_products_sku_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "sku"
+        }
+      ],
+      "name": "sku",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.Craftplan.Repo",
+  "schema": null,
+  "table": "catalog_products"
+}

--- a/priv/resource_snapshots/repo/inventory_material_nutritional_fact/20260623123557.json
+++ b/priv/resource_snapshots/repo/inventory_material_nutritional_fact/20260623123557.json
@@ -1,0 +1,129 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "amount",
+      "type": "decimal"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "unit",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"100\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "basis_quantity",
+      "type": "decimal"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"gram\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "basis_unit",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "inventory_material_nutritional_fact_material_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "inventory_materials"
+      },
+      "scale": null,
+      "size": null,
+      "source": "material_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "inventory_material_nutritional_fact_nutritional_fact_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "inventory_nutritional_facts"
+      },
+      "scale": null,
+      "size": null,
+      "source": "nutritional_fact_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "06E92F2E9769EA10114DDDCCD6CA7DE2E7516E3F83E59F9A6FC1E779D73ADF29",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.Craftplan.Repo",
+  "schema": null,
+  "table": "inventory_material_nutritional_fact"
+}

--- a/priv/resource_snapshots/repo/inventory_nutritional_facts/20260623123557.json
+++ b/priv/resource_snapshots/repo/inventory_nutritional_facts/20260623123557.json
@@ -1,0 +1,168 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "key",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"gram\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "default_unit",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "parent_key",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "1000",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "sort_order",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": false,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "eu_required",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": false,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "system",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "82AD2A1DB1BF43CB3B16B026ECF7AD0C45947093EDD073289DC56F2F07B0532D",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "inventory_nutritional_facts_name_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "name"
+        }
+      ],
+      "name": "name",
+      "nils_distinct?": true,
+      "where": null
+    },
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "inventory_nutritional_facts_key_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "key"
+        }
+      ],
+      "name": "key",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.Craftplan.Repo",
+  "schema": null,
+  "table": "inventory_nutritional_facts"
+}

--- a/test/craftplan/inventory/nutrition_test.exs
+++ b/test/craftplan/inventory/nutrition_test.exs
@@ -1,0 +1,173 @@
+defmodule Craftplan.Inventory.NutritionTest do
+  use Craftplan.DataCase, async: true
+
+  alias Craftplan.Catalog.BOM
+  alias Craftplan.Catalog.Product
+  alias Craftplan.Inventory.Material
+  alias Craftplan.Inventory.MaterialNutritionalFact
+  alias Craftplan.Inventory.Nutrition
+  alias Craftplan.Inventory.NutritionalFact
+
+  require Ash.Query
+
+  defp staff, do: Craftplan.DataCase.staff_actor()
+
+  defp material!(attrs \\ %{}) do
+    Material
+    |> Ash.Changeset.for_create(:create, %{
+      name: Map.get(attrs, :name, "Material-#{System.unique_integer()}"),
+      sku: Map.get(attrs, :sku, "MAT-#{System.unique_integer()}"),
+      unit: Map.get(attrs, :unit, :gram),
+      price: Map.get(attrs, :price, Decimal.new("1.00")),
+      minimum_stock: Decimal.new(0),
+      maximum_stock: Decimal.new(0)
+    })
+    |> Ash.create!(actor: staff())
+  end
+
+  defp fact!(name) do
+    key = Nutrition.standard_key_for_name(name) || Nutrition.custom_key(name)
+
+    case NutritionalFact |> Ash.Query.filter(key == ^key) |> Ash.read_one!(authorize?: false) do
+      nil ->
+        NutritionalFact
+        |> Ash.Changeset.for_create(:create, %{name: name})
+        |> Ash.create!(actor: staff())
+
+      fact ->
+        fact
+    end
+  end
+
+  test "legacy EU nutrient names are normalized to locked canonical facts" do
+    fact = fact!("Calories")
+
+    assert fact.key == "energy_kcal"
+    assert fact.name == "Energy (kcal)"
+    assert fact.default_unit == :kcal
+    assert fact.eu_required
+    assert fact.system
+  end
+
+  test "custom facts get stable custom keys" do
+    fact = fact!("Caffeine")
+
+    assert fact.key == "custom:caffeine"
+    refute fact.eu_required
+    refute fact.system
+  end
+
+  test "system nutrition facts cannot be deleted" do
+    fact = fact!("Salt")
+
+    assert {:error, changeset} = Ash.destroy(fact, actor: staff())
+    assert inspect(changeset.errors) =~ "system nutritional facts cannot be deleted"
+  end
+
+  test "material nutrition rejects child nutrients above parent nutrients" do
+    material = material!()
+    fat = fact!("Fat")
+    saturates = fact!("Saturated Fat")
+
+    params = %{
+      material_nutritional_facts: [
+        %{
+          material_id: material.id,
+          nutritional_fact_id: fat.id,
+          amount: Decimal.new("5"),
+          unit: :gram,
+          basis_quantity: Decimal.new("100"),
+          basis_unit: :gram
+        },
+        %{
+          material_id: material.id,
+          nutritional_fact_id: saturates.id,
+          amount: Decimal.new("6"),
+          unit: :gram,
+          basis_quantity: Decimal.new("100"),
+          basis_unit: :gram
+        }
+      ]
+    }
+
+    assert {:error, changeset} =
+             material
+             |> Ash.Changeset.for_update(:update_nutritional_facts, params)
+             |> Ash.update(actor: staff())
+
+    assert inspect(changeset.errors) =~ "saturates cannot exceed fat"
+  end
+
+  test "material nutrition rejects zero basis quantity" do
+    material = material!()
+    fat = fact!("Fat")
+
+    params = %{
+      material_nutritional_facts: [
+        %{
+          material_id: material.id,
+          nutritional_fact_id: fat.id,
+          amount: Decimal.new("5"),
+          unit: :gram,
+          basis_quantity: Decimal.new("0"),
+          basis_unit: :gram
+        }
+      ]
+    }
+
+    assert {:error, changeset} =
+             material
+             |> Ash.Changeset.for_update(:update_nutritional_facts, params)
+             |> Ash.update(actor: staff())
+
+    assert inspect(changeset.errors) =~ "basis_quantity must be greater than zero"
+  end
+
+  test "product nutrition is calculated per 100g when finished output is set" do
+    actor = staff()
+    material = material!()
+    fat = fact!("Fat")
+
+    MaterialNutritionalFact
+    |> Ash.Changeset.for_create(:create, %{
+      material_id: material.id,
+      nutritional_fact_id: fat.id,
+      amount: Decimal.new("10"),
+      unit: :gram,
+      basis_quantity: Decimal.new("100"),
+      basis_unit: :gram
+    })
+    |> Ash.create!(actor: actor)
+
+    product =
+      Product
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Product-#{System.unique_integer()}",
+        sku: "SKU-#{System.unique_integer()}",
+        price: Decimal.new("5.00"),
+        status: :active,
+        nutrition_output_quantity: Decimal.new("200"),
+        nutrition_output_unit: :gram
+      })
+      |> Ash.create!(actor: actor)
+
+    BOM
+    |> Ash.Changeset.for_create(:create, %{
+      product_id: product.id,
+      status: :active,
+      components: [
+        %{component_type: :material, material_id: material.id, quantity: Decimal.new("50")}
+      ]
+    })
+    |> Ash.create!(actor: actor)
+
+    product = Ash.load!(product, [:nutritional_facts], actor: actor)
+    [fact] = product.nutritional_facts
+
+    assert fact.key == "fat"
+    assert fact.declaration?
+    assert fact.per_quantity == Decimal.new("100")
+    assert fact.per_unit == :gram
+    assert Decimal.equal?(fact.amount, Decimal.new("2.5"))
+  end
+end

--- a/test/craftplan_web/manage_inventory_interactions_live_test.exs
+++ b/test/craftplan_web/manage_inventory_interactions_live_test.exs
@@ -40,11 +40,11 @@ defmodule CraftplanWeb.ManageInventoryInteractionsLiveTest do
     params = %{"movement" => %{"material_id" => m.id, "quantity" => "5", "reason" => "test"}}
 
     view
-    |> element("#movement-movment-form")
+    |> element("#movement-form")
     |> render_submit(params)
 
     assert_patch(view, ~p"/manage/inventory/#{m.sku}/stock")
-    assert render(view) =~ "Material created successfully"
+    assert render(view) =~ "Stock adjustment recorded"
   end
 
   @tag role: :staff
@@ -53,17 +53,17 @@ defmodule CraftplanWeb.ManageInventoryInteractionsLiveTest do
     {:ok, view, _} = live(conn, ~p"/manage/inventory/#{m.sku}/adjust")
 
     view
-    |> element("button[phx-click=toggle_adjustment_type][phx-value-type=add]")
+    |> element("button[phx-click=set_mode][phx-value-mode=add]")
     |> render_click()
 
     params = %{"movement" => %{"material_id" => m.id, "quantity" => "2", "reason" => "add"}}
 
     view
-    |> element("#movement-movment-form")
+    |> element("#movement-form")
     |> render_submit(params)
 
     assert_patch(view, ~p"/manage/inventory/#{m.sku}/stock")
-    assert render(view) =~ "Material created successfully"
+    assert render(view) =~ "Stock adjustment recorded"
   end
 
   @tag role: :staff
@@ -72,17 +72,17 @@ defmodule CraftplanWeb.ManageInventoryInteractionsLiveTest do
     {:ok, view, _} = live(conn, ~p"/manage/inventory/#{m.sku}/adjust")
 
     view
-    |> element("button[phx-click=toggle_adjustment_type][phx-value-type=subtract]")
+    |> element("button[phx-click=set_mode][phx-value-mode=subtract]")
     |> render_click()
 
     params = %{"movement" => %{"material_id" => m.id, "quantity" => "1", "reason" => "sub"}}
 
     view
-    |> element("#movement-movment-form")
+    |> element("#movement-form")
     |> render_submit(params)
 
     assert_patch(view, ~p"/manage/inventory/#{m.sku}/stock")
-    assert render(view) =~ "Material created successfully"
+    assert render(view) =~ "Stock adjustment recorded"
   end
 
   @tag role: :staff
@@ -107,7 +107,7 @@ defmodule CraftplanWeb.ManageInventoryInteractionsLiveTest do
   @tag role: :staff
   test "assign nutritional facts to material", %{conn: conn} do
     m = create_material!()
-    _nf = create_nf!()
+    nf = create_nf!()
     {:ok, view, _} = live(conn, ~p"/manage/inventory/#{m.sku}/nutritional_facts")
 
     # Open modal and click first available fact
@@ -117,8 +117,8 @@ defmodule CraftplanWeb.ManageInventoryInteractionsLiveTest do
 
     # Click any button inside the selection list
     view
-    |> element("button[phx-click=add_nutritional_fact]")
-    |> render_click(%{"fact-id" => "ignored"})
+    |> element("button[phx-click=add_nutritional_fact][phx-value-fact-id='#{nf.id}']")
+    |> render_click()
 
     view
     |> element("#material-nutritional-facts-form")

--- a/test/craftplan_web/manage_products_nutrition_live_test.exs
+++ b/test/craftplan_web/manage_products_nutrition_live_test.exs
@@ -7,17 +7,22 @@ defmodule CraftplanWeb.ManageProductsNutritionLiveTest do
   alias Craftplan.Catalog.Product
   alias Craftplan.Inventory.Material
   alias Craftplan.Inventory.MaterialNutritionalFact
+  alias Craftplan.Inventory.Nutrition
   alias Craftplan.Inventory.NutritionalFact
+
+  require Ash.Query
 
   defp staff, do: Craftplan.DataCase.staff_actor()
 
-  defp product! do
+  defp product!(attrs \\ %{}) do
     Product
     |> Ash.Changeset.for_create(:create, %{
       name: "P-#{System.unique_integer()}",
       sku: "SKU-#{System.unique_integer()}",
       price: Decimal.new("5.00"),
-      status: :active
+      status: :active,
+      nutrition_output_quantity: Map.get(attrs, :nutrition_output_quantity),
+      nutrition_output_unit: Map.get(attrs, :nutrition_output_unit)
     })
     |> Ash.create!(actor: staff())
   end
@@ -35,10 +40,7 @@ defmodule CraftplanWeb.ManageProductsNutritionLiveTest do
       })
       |> Ash.create!(actor: staff())
 
-    fact =
-      NutritionalFact
-      |> Ash.Changeset.for_create(:create, %{name: "Calories"})
-      |> Ash.create!(actor: staff())
+    fact = fact!("Calories")
 
     _link =
       MaterialNutritionalFact
@@ -46,11 +48,27 @@ defmodule CraftplanWeb.ManageProductsNutritionLiveTest do
         material_id: material.id,
         nutritional_fact_id: fact.id,
         amount: Decimal.new("57"),
-        unit: :gram
+        unit: :kcal,
+        basis_quantity: Decimal.new("100"),
+        basis_unit: :gram
       })
       |> Ash.create!(actor: staff())
 
     Ash.reload!(material, load: [material_nutritional_facts: [nutritional_fact: [:name]]])
+  end
+
+  defp fact!(name) do
+    key = Nutrition.standard_key_for_name(name) || Nutrition.custom_key(name)
+
+    case NutritionalFact |> Ash.Query.filter(key == ^key) |> Ash.read_one!(authorize?: false) do
+      nil ->
+        NutritionalFact
+        |> Ash.Changeset.for_create(:create, %{name: name})
+        |> Ash.create!(actor: staff())
+
+      fact ->
+        fact
+    end
   end
 
   @tag role: :staff
@@ -70,6 +88,26 @@ defmodule CraftplanWeb.ManageProductsNutritionLiveTest do
     {:ok, _view, html} = live(conn, ~p"/manage/products/#{p.sku}/nutrition")
 
     assert html =~ "Nutritional Facts"
-    assert html =~ "Calories"
+    assert html =~ "Energy (kcal)"
+  end
+
+  @tag role: :staff
+  test "nutrition tab renders per-100g declaration when product output is set", %{conn: conn} do
+    m = material_with_fact!()
+    p = product!(%{nutrition_output_quantity: Decimal.new("100"), nutrition_output_unit: :gram})
+
+    _bom =
+      BOM
+      |> Ash.Changeset.for_create(:create, %{
+        product_id: p.id,
+        status: :active,
+        components: [%{component_type: :material, material_id: m.id, quantity: Decimal.new(2)}]
+      })
+      |> Ash.create!(actor: staff())
+
+    {:ok, _view, html} = live(conn, ~p"/manage/products/#{p.sku}/nutrition")
+
+    assert html =~ "Nutrition Declaration"
+    assert html =~ "Per 100 g"
   end
 end


### PR DESCRIPTION
## Problem
Craftplan's nutrition model allowed arbitrary nutrient names and product nutrition totals, but it did not provide the standardized EU nutrition declaration structure that labels need. That made required nutrients inconsistent, prevented clear parent/child nutrients such as `of which saturates`, and left per-100g/ml declarations dependent on manual interpretation.

## Solution
Introduce canonical EU nutrition facts as protected system records, store per-material nutrition on an explicit basis, and calculate product nutrition declarations per 100g/ml when a finished output quantity is configured.

## Approach
- Add stable nutrient keys and metadata for EU-required facts while preserving custom nutrition facts.
- Backfill legacy nutrient names into canonical system facts and seed any missing required facts.
- Keep material entries flexible by storing amount, unit, basis quantity, and basis unit.
- Scale product nutrition from recipe components to a declaration basis only when the product has a valid gram or milliliter output.
- Surface the same ordered declaration in product views and printable labels.

## Changes
- Added `Craftplan.Inventory.Nutrition` and Ash changes for metadata assignment, system fact protection, and material nutrition validation.
- Added `kilojoule` to the shared unit enum and formatting helpers.
- Extended nutrition resources with canonical keys, default units, hierarchy metadata, EU-required/system flags, and per-material basis fields.
- Added product output quantity/unit fields used to calculate per-100g/ml nutrition declarations.
- Updated inventory, product, settings, and label LiveViews for ordered EU-style nutrition display and entry.
- Added migration, Ash resource snapshots, seed updates, and tests for canonical facts, validation, declaration calculations, and UI behavior.
- Refreshed stale inventory interaction selectors so the full suite matches the current stock-adjustment component.

## Tests
- `mix ash_postgres.generate_migrations --dry-run --domains Craftplan.Inventory,Craftplan.Catalog --name verify_nutrition`
- `mix format --check-formatted`
- `git diff --check`
- `MIX_ENV=test mix ecto.drop && mix test`

## Issues
Closes #21

Replaces #23, which was closed after renaming the original branch.
