### PR TITLE
perf(orders): bound orders-index load with date window, pagination, and view-aware calendar

### DIFF
--- a/lib/craftplan_web/live/manage/order_live/index.ex
+++ b/lib/craftplan_web/live/manage/order_live/index.ex
@@ -47,6 +47,7 @@ defmodule CraftplanWeb.OrderLive.Index do
       |> assign_new(:nav_sub_links, fn -> [] end)
       |> assign_new(:breadcrumbs, fn -> [] end)
       |> assign_new(:calendar_event_duration, fn -> @calendar_event_duration end)
+      |> assign_new(:page_size, fn -> @page_size end)
 
     ~H"""
     <Page.page>
@@ -188,6 +189,25 @@ defmodule CraftplanWeb.OrderLive.Index do
               <.badge text={"#{emoji_for_payment(order.payment_status)} #{order.payment_status}"} />
             </:col>
           </.table>
+          <div class="mt-4 flex items-center justify-between text-sm text-stone-600">
+            <span>{page_label(@page_offset, @page_size, @page_count)}</span>
+            <div class="flex items-center gap-2">
+              <.button
+                variant={:outline}
+                phx-click="prev_page"
+                disabled={@page_offset == 0}
+              >
+                Previous
+              </.button>
+              <.button
+                variant={:outline}
+                phx-click="next_page"
+                disabled={!@page_more}
+              >
+                Next
+              </.button>
+            </div>
+          </div>
         </Page.surface>
 
         <Page.surface
@@ -419,14 +439,30 @@ defmodule CraftplanWeb.OrderLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    socket = assign(socket, :filters, default_filters())
+    filters = default_filters()
+    filter_opts = parse_filters(filters)
 
-    filter_opts = parse_filters(default_filters())
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> assign(:products, Catalog.list_products!(actor: socket.assigns[:current_user]))
+      |> assign(
+        :customers,
+        CRM.list_customers!(actor: socket.assigns[:current_user], load: [:full_name])
+      )
+      |> assign(:days_range, calculate_days_range())
+      |> assign(:current_week_start, nil)
+      |> assign(:orders, [])
+      |> assign(:view_mode, "table")
+      |> assign(:calendar_events, [])
+      |> assign(:selected_order, nil)
+      |> assign(:page_offset, 0)
+      |> assign(:page_count, 0)
+      |> assign(:page_more, false)
+      |> stream(:orders, [])
+      |> load_table_page(filter_opts, 0)
 
-    {:ok,
-     socket
-     |> load_initial_data(filter_opts)
-     |> assign_initial_view_state()}
+    {:ok, socket}
   end
 
   @impl true
@@ -444,8 +480,7 @@ defmodule CraftplanWeb.OrderLive.Index do
       if socket.assigns.view_mode == view_mode do
         socket
       else
-        streamed_orders = load_streamed_orders(socket, filter_opts)
-        stream(socket, :orders, streamed_orders, reset: true)
+        load_table_page(socket, filter_opts, 0)
       end
 
     # Create calendar events from orders
@@ -469,22 +504,20 @@ defmodule CraftplanWeb.OrderLive.Index do
   @impl true
   def handle_event("reset_filters", _params, socket) do
     # Reset to default filters
-    socket = assign(socket, :filters, default_filters())
-    filter_opts = parse_filters(default_filters())
+    new_filters = default_filters()
+    socket = assign(socket, :filters, new_filters)
+    filter_opts = parse_filters(new_filters)
 
     orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-    streamed_orders = load_streamed_orders(socket, filter_opts)
 
     calendar_events =
       create_calendar_events(orders_for_calendar, @calendar_event_duration)
 
-    socket =
-      socket
-      |> assign(:orders, orders_for_calendar)
-      |> assign(:calendar_events, calendar_events)
-      |> stream(:orders, streamed_orders, reset: true)
-
-    {:noreply, socket}
+    {:noreply,
+     socket
+     |> assign(:orders, orders_for_calendar)
+     |> assign(:calendar_events, calendar_events)
+     |> load_table_page(filter_opts, 0)}
   end
 
   @impl true
@@ -553,17 +586,28 @@ defmodule CraftplanWeb.OrderLive.Index do
     filter_opts = parse_filters(new_filters)
 
     orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-    streamed_orders = load_streamed_orders(socket, filter_opts)
-
-    calendar_events =
-      create_calendar_events(orders_for_calendar, @calendar_event_duration)
+    calendar_events = create_calendar_events(orders_for_calendar, @calendar_event_duration)
 
     {:noreply,
      socket
      |> assign(:filters, new_filters)
      |> assign(:orders, orders_for_calendar)
      |> assign(:calendar_events, calendar_events)
-     |> stream(:orders, streamed_orders, reset: true)}
+     |> load_table_page(filter_opts, 0)}
+  end
+
+  @impl true
+  def handle_event("next_page", _params, socket) do
+    filter_opts = parse_filters(socket.assigns.filters)
+    offset = socket.assigns.page_offset + @page_size
+    {:noreply, load_table_page(socket, filter_opts, offset)}
+  end
+
+  @impl true
+  def handle_event("prev_page", _params, socket) do
+    filter_opts = parse_filters(socket.assigns.filters)
+    offset = max(0, socket.assigns.page_offset - @page_size)
+    {:noreply, load_table_page(socket, filter_opts, offset)}
   end
 
   @impl true
@@ -602,7 +646,6 @@ defmodule CraftplanWeb.OrderLive.Index do
     filter_opts = parse_filters(new_filters)
 
     orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-    streamed_orders = load_streamed_orders(socket, filter_opts)
 
     calendar_events =
       create_calendar_events(orders_for_calendar, @calendar_event_duration)
@@ -612,7 +655,7 @@ defmodule CraftplanWeb.OrderLive.Index do
      |> assign(:filters, new_filters)
      |> assign(:orders, orders_for_calendar)
      |> assign(:calendar_events, calendar_events)
-     |> stream(:orders, streamed_orders, reset: true)
+     |> load_table_page(filter_opts, 0)
      |> push_event("update-calendar", %{events: calendar_events})}
   end
 
@@ -633,42 +676,32 @@ defmodule CraftplanWeb.OrderLive.Index do
 
   # Private helper functions
 
-  defp load_initial_data(socket, filter_opts) do
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-    streamed_orders = load_streamed_orders(socket, filter_opts)
-    products = Catalog.list_products!(actor: socket.assigns[:current_user])
-    customers = CRM.list_customers!(actor: socket.assigns[:current_user], load: [:full_name])
-    days_range = calculate_days_range()
+  defp load_table_page(socket, filter_opts, offset) do
+    page =
+      Orders.list_orders!(
+        filter_opts,
+        actor: socket.assigns[:current_user],
+        page: [limit: @page_size, offset: offset, count: true],
+        load: [:items, :total_cost, customer: [:full_name], items: [product: [:name]]]
+      )
 
     socket
-    |> assign(:products, products)
-    |> assign(:customers, customers)
-    |> assign(:orders, orders_for_calendar)
-    |> assign(:days_range, days_range)
-    |> assign(:current_week_start, nil)
-    |> stream(:orders, streamed_orders)
+    |> assign(:page_offset, page.offset)
+    |> assign(:page_count, page.count)
+    |> assign(:page_more, page.more?)
+    |> stream(:orders, page.results, reset: true)
   end
 
-  defp assign_initial_view_state(socket) do
-    socket
-    |> assign(:view_mode, "table")
-    |> assign(:calendar_events, [])
-    |> assign(:selected_order, nil)
+  defp page_label(_offset, _page_size, 0), do: "No orders"
+
+  defp page_label(offset, page_size, count) do
+    "Showing #{offset + 1}-#{min(offset + page_size, count)} of #{count}"
   end
 
   defp load_orders_for_calendar(socket, filter_opts) do
     Orders.list_orders!(
       filter_opts,
       actor: socket.assigns[:current_user],
-      load: [:items, :total_cost, customer: [:full_name], items: [product: [:name]]]
-    )
-  end
-
-  defp load_streamed_orders(socket, filter_opts) do
-    Orders.list_orders!(
-      filter_opts,
-      actor: socket.assigns[:current_user],
-      stream?: true,
       load: [:items, :total_cost, customer: [:full_name], items: [product: [:name]]]
     )
   end

--- a/lib/craftplan_web/live/manage/order_live/index.ex
+++ b/lib/craftplan_web/live/manage/order_live/index.ex
@@ -622,9 +622,11 @@ defmodule CraftplanWeb.OrderLive.Index do
       |> assign(:filters, new_filters)
       |> load_view_data(socket.assigns.view_mode, filter_opts)
 
-    calendar_events = socket.assigns.calendar_events
-
-    {:noreply, push_event(socket, "update-calendar", %{events: calendar_events})}
+    if socket.assigns.view_mode == "calendar" do
+      {:noreply, push_event(socket, "update-calendar", %{events: socket.assigns.calendar_events})}
+    else
+      {:noreply, socket}
+    end
   end
 
   @impl true

--- a/lib/craftplan_web/live/manage/order_live/index.ex
+++ b/lib/craftplan_web/live/manage/order_live/index.ex
@@ -468,34 +468,14 @@ defmodule CraftplanWeb.OrderLive.Index do
   @impl true
   def handle_params(params, _url, socket) do
     view_mode = Map.get(params, "view", "table")
-
-    # Reload orders to ensure consistency between views
     filter_opts = parse_filters(socket.assigns.filters)
-
-    # Get orders for both views with the current filters
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-
-    # Only update the stream if the view mode changed to ensure consistency
-    socket =
-      if socket.assigns.view_mode == view_mode do
-        socket
-      else
-        load_table_page(socket, filter_opts, 0)
-      end
-
-    # Create calendar events from orders
-    calendar_events =
-      create_calendar_events(orders_for_calendar, @calendar_event_duration)
-
-    # Calculate days range for calendar
     days_range = calculate_days_range(socket.assigns[:current_week_start])
 
     socket =
       socket
       |> assign(:view_mode, view_mode)
-      |> assign(:orders, orders_for_calendar)
-      |> assign(:calendar_events, calendar_events)
       |> assign(:days_range, days_range)
+      |> load_view_data(view_mode, filter_opts)
       |> apply_action(socket.assigns.live_action, params)
 
     {:noreply, Navigation.assign(socket, :orders, order_trail(socket.assigns))}
@@ -503,68 +483,66 @@ defmodule CraftplanWeb.OrderLive.Index do
 
   @impl true
   def handle_event("reset_filters", _params, socket) do
-    # Reset to default filters
     new_filters = default_filters()
-    socket = assign(socket, :filters, new_filters)
     filter_opts = parse_filters(new_filters)
-
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-
-    calendar_events =
-      create_calendar_events(orders_for_calendar, @calendar_event_duration)
 
     {:noreply,
      socket
-     |> assign(:orders, orders_for_calendar)
-     |> assign(:calendar_events, calendar_events)
-     |> load_table_page(filter_opts, 0)}
+     |> assign(:filters, new_filters)
+     |> load_view_data(socket.assigns.view_mode, filter_opts)}
   end
 
   @impl true
   def handle_event("prev_week", _params, socket) do
-    # Move the date range backward by 7 days
     new_start = Date.add(List.first(socket.assigns.days_range), -7)
     days_range = date_range(new_start)
-
     filter_opts = parse_filters(socket.assigns.filters)
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
+    orders_for_calendar = load_orders_for_calendar(socket, filter_opts, days_range)
 
     {:noreply,
      socket
      |> assign(:current_week_start, new_start)
      |> assign(:days_range, days_range)
-     |> assign(:orders, orders_for_calendar)}
+     |> assign(:orders, orders_for_calendar)
+     |> assign(
+       :calendar_events,
+       create_calendar_events(orders_for_calendar, @calendar_event_duration)
+     )}
   end
 
   @impl true
   def handle_event("next_week", _params, socket) do
-    # Move the date range forward by 7 days
     new_start = Date.add(List.first(socket.assigns.days_range), 7)
     days_range = date_range(new_start)
-
     filter_opts = parse_filters(socket.assigns.filters)
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
+    orders_for_calendar = load_orders_for_calendar(socket, filter_opts, days_range)
 
     {:noreply,
      socket
      |> assign(:current_week_start, new_start)
      |> assign(:days_range, days_range)
-     |> assign(:orders, orders_for_calendar)}
+     |> assign(:orders, orders_for_calendar)
+     |> assign(
+       :calendar_events,
+       create_calendar_events(orders_for_calendar, @calendar_event_duration)
+     )}
   end
 
   @impl true
   def handle_event("today", _params, socket) do
-    # Reset to current day and forward
     days_range = calculate_days_range()
-
     filter_opts = parse_filters(socket.assigns.filters)
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
+    orders_for_calendar = load_orders_for_calendar(socket, filter_opts, days_range)
 
     {:noreply,
      socket
      |> assign(:current_week_start, nil)
      |> assign(:days_range, days_range)
-     |> assign(:orders, orders_for_calendar)}
+     |> assign(:orders, orders_for_calendar)
+     |> assign(
+       :calendar_events,
+       create_calendar_events(orders_for_calendar, @calendar_event_duration)
+     )}
   end
 
   @impl true
@@ -585,15 +563,10 @@ defmodule CraftplanWeb.OrderLive.Index do
     new_filters = Map.merge(socket.assigns.filters, raw_filters)
     filter_opts = parse_filters(new_filters)
 
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
-    calendar_events = create_calendar_events(orders_for_calendar, @calendar_event_duration)
-
     {:noreply,
      socket
      |> assign(:filters, new_filters)
-     |> assign(:orders, orders_for_calendar)
-     |> assign(:calendar_events, calendar_events)
-     |> load_table_page(filter_opts, 0)}
+     |> load_view_data(socket.assigns.view_mode, filter_opts)}
   end
 
   @impl true
@@ -637,7 +610,6 @@ defmodule CraftplanWeb.OrderLive.Index do
         %{"start_date" => start_date, "end_date" => end_date, "view_type" => _view_type},
         socket
       ) do
-    # Update filters with new date ranges
     new_filters =
       socket.assigns.filters
       |> Map.put("delivery_date_start", start_date)
@@ -645,33 +617,20 @@ defmodule CraftplanWeb.OrderLive.Index do
 
     filter_opts = parse_filters(new_filters)
 
-    orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
+    socket =
+      socket
+      |> assign(:filters, new_filters)
+      |> load_view_data(socket.assigns.view_mode, filter_opts)
 
-    calendar_events =
-      create_calendar_events(orders_for_calendar, @calendar_event_duration)
+    calendar_events = socket.assigns.calendar_events
 
-    {:noreply,
-     socket
-     |> assign(:filters, new_filters)
-     |> assign(:orders, orders_for_calendar)
-     |> assign(:calendar_events, calendar_events)
-     |> load_table_page(filter_opts, 0)
-     |> push_event("update-calendar", %{events: calendar_events})}
+    {:noreply, push_event(socket, "update-calendar", %{events: calendar_events})}
   end
 
   @impl true
-  def handle_info({CraftplanWeb.OrderLive.FormComponent, {:saved, order}}, socket) do
-    order =
-      Ash.load!(order, [:items, :total_cost, customer: [:full_name]], actor: socket.assigns[:current_user])
-
-    orders = [order | socket.assigns.orders || []]
-    calendar_events = create_calendar_events(orders, @calendar_event_duration)
-
-    {:noreply,
-     socket
-     |> stream_insert(:orders, order)
-     |> assign(:orders, orders)
-     |> assign(:calendar_events, calendar_events)}
+  def handle_info({CraftplanWeb.OrderLive.FormComponent, {:saved, _order}}, socket) do
+    filter_opts = parse_filters(socket.assigns.filters)
+    {:noreply, load_view_data(socket, socket.assigns.view_mode, filter_opts)}
   end
 
   # Private helper functions
@@ -698,12 +657,38 @@ defmodule CraftplanWeb.OrderLive.Index do
     "Showing #{offset + 1}-#{min(offset + page_size, count)} of #{count}"
   end
 
-  defp load_orders_for_calendar(socket, filter_opts) do
+  def calendar_window(days_range) do
+    week_start = List.first(days_range)
+    week_end = List.last(days_range)
+
+    {DateTime.new!(week_start, ~T[00:00:00], "Etc/UTC"), DateTime.new!(week_end, ~T[23:59:59], "Etc/UTC")}
+  end
+
+  defp load_orders_for_calendar(socket, filter_opts, days_range) do
+    {start_dt, end_dt} = calendar_window(days_range)
+
+    cal_opts =
+      filter_opts
+      |> Map.put(:delivery_date_start, start_dt)
+      |> Map.put(:delivery_date_end, end_dt)
+
     Orders.list_orders!(
-      filter_opts,
+      cal_opts,
       actor: socket.assigns[:current_user],
       load: [:items, :total_cost, customer: [:full_name], items: [product: [:name]]]
     )
+  end
+
+  defp load_view_data(socket, "calendar", filter_opts) do
+    orders = load_orders_for_calendar(socket, filter_opts, socket.assigns.days_range)
+
+    socket
+    |> assign(:orders, orders)
+    |> assign(:calendar_events, create_calendar_events(orders, @calendar_event_duration))
+  end
+
+  defp load_view_data(socket, _table, filter_opts) do
+    load_table_page(socket, filter_opts, 0)
   end
 
   defp apply_action(socket, :new, _params) do

--- a/lib/craftplan_web/live/manage/order_live/index.ex
+++ b/lib/craftplan_web/live/manage/order_live/index.ex
@@ -21,16 +21,24 @@ defmodule CraftplanWeb.OrderLive.Index do
           customer_name: String.t() | nil
         }
 
-  @default_filters %{
-    "status" => [],
-    "payment_status" => [],
-    "delivery_date_start" => "",
-    "delivery_date_end" => "",
-    "customer_name" => ""
-  }
-
   # Calendar event duration in seconds
   @calendar_event_duration 3600
+
+  @page_size 100
+  @window_past_days 7
+  @window_future_days 90
+
+  defp default_filters do
+    today = Date.utc_today()
+
+    %{
+      "status" => [],
+      "payment_status" => [],
+      "delivery_date_start" => Date.to_iso8601(Date.add(today, -@window_past_days)),
+      "delivery_date_end" => Date.to_iso8601(Date.add(today, @window_future_days)),
+      "customer_name" => ""
+    }
+  end
 
   @impl true
   def render(assigns) do
@@ -411,9 +419,9 @@ defmodule CraftplanWeb.OrderLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    socket = assign(socket, :filters, @default_filters)
+    socket = assign(socket, :filters, default_filters())
 
-    filter_opts = parse_filters(@default_filters)
+    filter_opts = parse_filters(default_filters())
 
     {:ok,
      socket
@@ -461,8 +469,8 @@ defmodule CraftplanWeb.OrderLive.Index do
   @impl true
   def handle_event("reset_filters", _params, socket) do
     # Reset to default filters
-    socket = assign(socket, :filters, @default_filters)
-    filter_opts = parse_filters(@default_filters)
+    socket = assign(socket, :filters, default_filters())
+    filter_opts = parse_filters(default_filters())
 
     orders_for_calendar = load_orders_for_calendar(socket, filter_opts)
     streamed_orders = load_streamed_orders(socket, filter_opts)

--- a/test/craftplan_web/manage_orders_perf_live_test.exs
+++ b/test/craftplan_web/manage_orders_perf_live_test.exs
@@ -48,7 +48,6 @@ defmodule CraftplanWeb.ManageOrdersPerfLiveTest do
   end
 
   describe "calendar window scoping" do
-    @tag role: :staff
     test "calendar_window/1 bounds the first..last day of the range in UTC" do
       range = [
         ~D[2026-06-22],

--- a/test/craftplan_web/manage_orders_perf_live_test.exs
+++ b/test/craftplan_web/manage_orders_perf_live_test.exs
@@ -20,6 +20,33 @@ defmodule CraftplanWeb.ManageOrdersPerfLiveTest do
 
   defp days_from_now(days), do: DateTime.add(DateTime.utc_now(), days * 86_400, :second)
 
+  describe "table pagination" do
+    @tag role: :staff
+    test "shows 100 of N and pages through the rest", %{conn: conn} do
+      customer = Factory.create_customer!(%{first_name: "Page", last_name: "Tester"})
+      product = Factory.create_product!()
+
+      for _ <- 1..120 do
+        Factory.create_order_with_items!(
+          customer,
+          [%{product_id: product.id, quantity: 1, unit_price: product.price}],
+          delivery_date: DateTime.add(DateTime.utc_now(), 86_400, :second)
+        )
+      end
+
+      {:ok, view, html} = live(conn, ~p"/manage/orders")
+      assert html =~ "Showing 1-100 of 120"
+      assert has_element?(view, "button[phx-click=next_page]:not([disabled])")
+
+      next = view |> element("button[phx-click=next_page]") |> render_click()
+      assert next =~ "Showing 101-120 of 120"
+      assert has_element?(view, "button[phx-click=prev_page]:not([disabled])")
+
+      prev = view |> element("button[phx-click=prev_page]") |> render_click()
+      assert prev =~ "Showing 1-100 of 120"
+    end
+  end
+
   describe "default delivery-date window" do
     @tag role: :staff
     test "pre-fills the date pickers with today-7 / today+90", %{conn: conn} do

--- a/test/craftplan_web/manage_orders_perf_live_test.exs
+++ b/test/craftplan_web/manage_orders_perf_live_test.exs
@@ -1,0 +1,51 @@
+defmodule CraftplanWeb.ManageOrdersPerfLiveTest do
+  use CraftplanWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Craftplan.Test.Factory
+
+  defp order_at(delivery_date, customer_name) do
+    customer = Factory.create_customer!(%{first_name: customer_name, last_name: "Perf"})
+
+    product =
+      Factory.create_product!(%{name: "Perf Product #{System.unique_integer([:positive])}"})
+
+    Factory.create_order_with_items!(
+      customer,
+      [%{product_id: product.id, quantity: 1, unit_price: product.price}],
+      delivery_date: delivery_date
+    )
+  end
+
+  defp days_from_now(days), do: DateTime.add(DateTime.utc_now(), days * 86_400, :second)
+
+  describe "default delivery-date window" do
+    @tag role: :staff
+    test "pre-fills the date pickers with today-7 / today+90", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/manage/orders")
+      today = Date.utc_today()
+      assert html =~ Date.to_iso8601(Date.add(today, -7))
+      assert html =~ Date.to_iso8601(Date.add(today, 90))
+    end
+
+    @tag role: :staff
+    test "excludes orders outside the window, includes them after clearing dates", %{conn: conn} do
+      _in_window = order_at(days_from_now(1), "InWindow")
+      _out_of_window = order_at(days_from_now(-60), "WayBack")
+
+      {:ok, view, html} = live(conn, ~p"/manage/orders")
+      assert html =~ "InWindow"
+      refute html =~ "WayBack"
+
+      cleared =
+        view
+        |> element("#filters-form")
+        |> render_change(%{
+          "filters" => %{"delivery_date_start" => "", "delivery_date_end" => ""}
+        })
+
+      assert cleared =~ "WayBack"
+    end
+  end
+end

--- a/test/craftplan_web/manage_orders_perf_live_test.exs
+++ b/test/craftplan_web/manage_orders_perf_live_test.exs
@@ -47,6 +47,76 @@ defmodule CraftplanWeb.ManageOrdersPerfLiveTest do
     end
   end
 
+  describe "calendar window scoping" do
+    @tag role: :staff
+    test "calendar_window/1 bounds the first..last day of the range in UTC" do
+      range = [
+        ~D[2026-06-22],
+        ~D[2026-06-23],
+        ~D[2026-06-24],
+        ~D[2026-06-25],
+        ~D[2026-06-26],
+        ~D[2026-06-27],
+        ~D[2026-06-28]
+      ]
+
+      {start_dt, end_dt} = CraftplanWeb.OrderLive.Index.calendar_window(range)
+
+      assert start_dt == ~U[2026-06-22 00:00:00Z]
+      assert end_dt == ~U[2026-06-28 23:59:59Z]
+    end
+
+    @tag role: :staff
+    test "calendar shows this week's order and not next week's, and flips on navigation",
+         %{conn: conn} do
+      week_start = Date.add(Date.utc_today(), -(Date.day_of_week(Date.utc_today()) - 1))
+      this_week = DateTime.new!(Date.add(week_start, 1), ~T[10:00:00], "Etc/UTC")
+      next_week = DateTime.new!(Date.add(week_start, 8), ~T[10:00:00], "Etc/UTC")
+
+      _c1 = order_at(this_week, "ThisWeekCust")
+      _c2 = order_at(next_week, "NextWeekCust")
+
+      {:ok, view, html} = live(conn, ~p"/manage/orders?view=calendar")
+      assert html =~ "ThisWeekCust"
+      refute html =~ "NextWeekCust"
+
+      flipped = view |> element("button[phx-click=next_week]") |> render_click()
+      assert flipped =~ "NextWeekCust"
+      refute flipped =~ "ThisWeekCust"
+    end
+  end
+
+  describe "count refresh on saved order" do
+    @tag role: :staff
+    test "creating an in-window order refreshes the count label", %{conn: conn} do
+      customer = Factory.create_customer!(%{first_name: "Refresh", last_name: "Counts"})
+      product = Factory.create_product!()
+
+      _existing =
+        Factory.create_order_with_items!(
+          customer,
+          [%{product_id: product.id, quantity: 1, unit_price: product.price}],
+          delivery_date: DateTime.add(DateTime.utc_now(), 86_400, :second)
+        )
+
+      {:ok, view, html} = live(conn, ~p"/manage/orders")
+      assert html =~ "of 1"
+
+      send(
+        view.pid,
+        {CraftplanWeb.OrderLive.FormComponent,
+         {:saved,
+          Factory.create_order_with_items!(
+            customer,
+            [%{product_id: product.id, quantity: 1, unit_price: product.price}],
+            delivery_date: DateTime.add(DateTime.utc_now(), 2 * 86_400, :second)
+          )}}
+      )
+
+      assert render(view) =~ "of 2"
+    end
+  end
+
   describe "default delivery-date window" do
     @tag role: :staff
     test "pre-fills the date pickers with today-7 / today+90", %{conn: conn} do

--- a/test/craftplan_web/manage_orders_perf_live_test.exs
+++ b/test/craftplan_web/manage_orders_perf_live_test.exs
@@ -1,5 +1,9 @@
 defmodule CraftplanWeb.ManageOrdersPerfLiveTest do
-  use CraftplanWeb.ConnCase, async: true
+  # async: false — the pagination test seeds 100+ orders in one test, holding its
+  # sandbox connection long enough to exceed the 15s checkout timeout when run
+  # concurrently with the other order suites. Running this module serially avoids
+  # starving the connection pool.
+  use CraftplanWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
 


### PR DESCRIPTION
## Problem

On instances with many historical orders, `OrderLive.Index` loads *every* order
on every mount and every filter change — for both the stream-backed table and the
calendar. With thousands of rows this causes slow initial mounts, large LiveView
payloads, and redundant queries even when the user is only looking at the table.

## Changes

**1 — Delivery-date window default.** The filter's date pickers pre-populate to
`today − 7 days … today + 90 days` on mount and on Reset, bounding the query.
Clearing either date shows full history — the window is a default, not a hard
constraint. Constants `@page_size 100`, `@window_past_days 7`,
`@window_future_days 90` document the policy in one place.

**2 — Offset pagination.** The unbounded `stream?: true` load is replaced by
`Ash.Page.Offset` at 100/page. Prev/Next buttons and a "Showing X–Y of N" label
render below the table; buttons disable at the boundaries. (`OrderLive.Index`'s
`:list` action already supports offset pagination.)

**3 — Week-scoped calendar + per-view load.** `calendar_window/1` turns the
visible 7-day range into `{start_dt, end_dt}`; the calendar query is bounded to
that week (so week-nav never queries beyond it). `load_view_data/3` dispatches to
either the paged table load or the calendar load, so switching views — or saving
an order — only queries the active surface.

**4 — Test suite.** `test/craftplan_web/manage_orders_perf_live_test.exs` covers
pagination labels/buttons (120 orders), calendar week-scoping, the default-window
behavior, and a `calendar_window/1` unit test. (`async: false` to avoid sandbox
pool starvation when seeding many rows.)

## Notes

- No schema changes. Date rendering in the table/calendar is left exactly as
  upstream has it.
- `calendar_window/1` is `def` (public) to allow a direct unit test; can be made
  `defp` if you prefer.
- Developed/tested on a fork (Elixir 1.18). Please let upstream CI confirm on 1.20.
