### PR TITLE
perf(inventory): load reorder forecast metrics asynchronously

### DIFF
--- a/lib/craftplan_web/live/manage/inventory_live/reorder.ex
+++ b/lib/craftplan_web/live/manage/inventory_live/reorder.ex
@@ -272,7 +272,7 @@ defmodule CraftplanWeb.InventoryLive.ReorderPlanner do
       |> assign_forecast_defaults(session, settings)
       |> assign_advanced_defaults(settings)
 
-    {:ok, load_metrics(socket)}
+    {:ok, maybe_start_metrics(socket)}
   end
 
   defp assign_advanced_defaults(socket, settings) do
@@ -409,6 +409,55 @@ defmodule CraftplanWeb.InventoryLive.ReorderPlanner do
   defp maybe_update_min_samples(socket, _), do: socket
 
   ## Metrics loading
+
+  defp maybe_start_metrics(socket) do
+    if connected?(socket), do: start_metrics_load(socket), else: socket
+  end
+
+  defp start_metrics_load(%{assigns: %{horizon_days: horizon}} = socket) when horizon <= 0 do
+    socket
+  end
+
+  defp start_metrics_load(socket) do
+    days_range = build_days_range(socket.assigns.today, socket.assigns.horizon_days)
+    actor = socket.assigns[:current_user]
+
+    opts = [
+      service_level: socket.assigns.service_level,
+      lookback_days: socket.assigns.lookback_days,
+      actual_weight: socket.assigns.actual_weight,
+      planned_weight: socket.assigns.planned_weight,
+      min_samples: socket.assigns.min_samples
+    ]
+
+    socket
+    |> assign(:metrics_loaded?, false)
+    |> assign(:forecast_error, nil)
+    |> assign(:days_range, days_range)
+    |> cancel_async(:forecast_metrics)
+    |> start_async(:forecast_metrics, fn ->
+      InventoryForecasting.owner_grid_rows(days_range, opts, actor)
+    end)
+  end
+
+  @impl true
+  def handle_async(:forecast_metrics, {:ok, rows}, socket) do
+    {:noreply,
+     socket
+     |> assign(:forecast_rows, rows)
+     |> assign(:metrics_loaded?, true)
+     |> assign(:forecast_error, nil)}
+  end
+
+  def handle_async(:forecast_metrics, {:exit, reason}, socket) do
+    Logger.error("Unable to load owner forecast metrics: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> assign(:forecast_rows, [])
+     |> assign(:metrics_loaded?, false)
+     |> assign(:forecast_error, "Unable to load forecast metrics right now.")}
+  end
 
   defp refresh_metrics(socket, assigns) do
     socket

--- a/lib/craftplan_web/live/manage/inventory_live/reorder.ex
+++ b/lib/craftplan_web/live/manage/inventory_live/reorder.ex
@@ -349,7 +349,7 @@ defmodule CraftplanWeb.InventoryLive.ReorderPlanner do
       |> maybe_update_planned_weight(params)
       |> maybe_update_min_samples(params)
 
-    {:noreply, load_metrics(socket)}
+    {:noreply, start_metrics_load(socket)}
   end
 
   @impl true
@@ -369,7 +369,7 @@ defmodule CraftplanWeb.InventoryLive.ReorderPlanner do
       )
       |> assign(:min_samples, Map.get(settings, :forecast_min_samples) || 10)
 
-    {:noreply, load_metrics(socket)}
+    {:noreply, start_metrics_load(socket)}
   end
 
   defp maybe_update_lookback_days(socket, %{"lookback_days" => value}) do
@@ -462,45 +462,7 @@ defmodule CraftplanWeb.InventoryLive.ReorderPlanner do
   defp refresh_metrics(socket, assigns) do
     socket
     |> assign(assigns)
-    |> load_metrics()
-  end
-
-  defp load_metrics(%{assigns: %{horizon_days: horizon}} = socket) when horizon <= 0 do
-    socket
-  end
-
-  defp load_metrics(socket) do
-    days_range = build_days_range(socket.assigns.today, socket.assigns.horizon_days)
-    actor = socket.assigns[:current_user]
-
-    socket = assign(socket, :metrics_loaded?, false)
-
-    opts = [
-      service_level: socket.assigns.service_level,
-      lookback_days: socket.assigns.lookback_days,
-      actual_weight: socket.assigns.actual_weight,
-      planned_weight: socket.assigns.planned_weight,
-      min_samples: socket.assigns.min_samples
-    ]
-
-    rows = InventoryForecasting.owner_grid_rows(days_range, opts, actor)
-
-    socket
-    |> assign(:forecast_rows, rows)
-    |> assign(:metrics_loaded?, true)
-    |> assign(:forecast_error, nil)
-    |> assign(:days_range, days_range)
-  rescue
-    exception ->
-      Logger.error("Unable to load owner forecast metrics: #{Exception.message(exception)}",
-        exception: exception,
-        stacktrace: __STACKTRACE__
-      )
-
-      socket
-      |> assign(:forecast_rows, [])
-      |> assign(:metrics_loaded?, false)
-      |> assign(:forecast_error, "Unable to load forecast metrics right now.")
+    |> start_metrics_load()
   end
 
   defp build_days_range(start_date, days) when days > 0 do

--- a/test/craftplan_web/manage_inventory_reorder_live_test.exs
+++ b/test/craftplan_web/manage_inventory_reorder_live_test.exs
@@ -24,5 +24,23 @@ defmodule CraftplanWeb.ManageInventoryReorderLiveTest do
       refute resolved =~ "Loading inventory metrics"
       assert resolved =~ "No forecast rows available" or resolved =~ "owner-metrics-band"
     end
+
+    @tag role: :staff
+    test "changing the horizon recomputes asynchronously (no blocking)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/manage/inventory/forecast/reorder")
+      render_async(view)
+
+      clicked =
+        view
+        |> element(~s(button[phx-click="set_horizon"][phx-value-days="28"]))
+        |> render_click()
+
+      # The toggle handler returned without blocking on the recompute:
+      # the spinner is shown again.
+      assert clicked =~ "Loading inventory metrics"
+
+      resolved = render_async(view)
+      refute resolved =~ "Loading inventory metrics"
+    end
   end
 end

--- a/test/craftplan_web/manage_inventory_reorder_live_test.exs
+++ b/test/craftplan_web/manage_inventory_reorder_live_test.exs
@@ -1,0 +1,28 @@
+defmodule CraftplanWeb.ManageInventoryReorderLiveTest do
+  # async: false + shared sandbox — the page computes metrics in a start_async
+  # task; shared mode guarantees that task can reach the test's DB connection.
+  use CraftplanWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.mode(Craftplan.Repo, {:shared, self()})
+    :ok
+  end
+
+  describe "async metrics load" do
+    @tag role: :staff
+    test "mount returns immediately with the loading state, then resolves async", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/manage/inventory/forecast/reorder")
+
+      # Mount did NOT block on the ~2s computation: spinner is shown.
+      assert html =~ "Loading inventory metrics"
+
+      # Awaiting the async assign clears the spinner and renders the band
+      # (empty state is fine with no seeded data).
+      resolved = render_async(view)
+      refute resolved =~ "Loading inventory metrics"
+      assert resolved =~ "No forecast rows available" or resolved =~ "owner-metrics-band"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On instances with a year of order history, `/manage/inventory/forecast/reorder`
blocked the LiveView WebSocket join for ~2s while computing forecast metrics
synchronously in `mount/3`. The browser hit the socket reconnect timeout and
reloaded the page in a loop, making the page effectively unusable on production
data.

## What changed

`CraftplanWeb.InventoryLive.ReorderPlanner` (`lib/craftplan_web/live/manage/inventory_live/reorder.ex`):

- `mount/3` now calls `maybe_start_metrics/1`, a no-op during the disconnected
  (static) render that fires `start_async/3` only on the connected WebSocket join.
- `start_metrics_load/1` replaces the synchronous `load_metrics/1`: it sets the
  loading flag, cancels any in-flight task via `cancel_async/2`, then launches a
  new async task. The control-toggle handlers (service level / horizon / advanced
  settings) now call it too, so changing a control no longer freezes the page.
- `handle_async/3` replaces the inline `rescue`: success assigns rows and sets
  `metrics_loaded?: true`; an `{:exit, reason}` assigns the same error string as
  before.
- The loading UI (spinner + "Loading inventory metrics…") already existed but was
  never actually shown under the old synchronous path.

Adds `test/craftplan_web/manage_inventory_reorder_live_test.exs` (two tests using
`render_async/1` to assert the spinner → resolved transition and that control
changes re-trigger async load without blocking).

## Notes

- No schema or public API changes. Touches exactly two files.
- Developed and tested on a fork (Elixir 1.18 / OTP 27). Please let upstream CI
  confirm on Elixir 1.20.
