### PR TITLE
fix(customers): guard nil billing/shipping address on customer show page

### DIFF
--- a/lib/craftplan_web/live/manage/customer_live/show.ex
+++ b/lib/craftplan_web/live/manage/customer_live/show.ex
@@ -26,8 +26,12 @@ defmodule CraftplanWeb.CustomerLive.Show do
               <:item title="Name">{@customer.full_name}</:item>
               <:item title="Email">{@customer.email}</:item>
               <:item title="Phone">{@customer.phone}</:item>
-              <:item title="Billing Address">{@customer.billing_address.full_address}</:item>
-              <:item title="Shipping Address">{@customer.shipping_address.full_address}</:item>
+              <:item title="Billing Address">
+                {@customer.billing_address && @customer.billing_address.full_address}
+              </:item>
+              <:item title="Shipping Address">
+                {@customer.shipping_address && @customer.shipping_address.full_address}
+              </:item>
             </.list>
           </div>
         </div>

--- a/test/craftplan_web/manage_customers_live_test.exs
+++ b/test/craftplan_web/manage_customers_live_test.exs
@@ -53,6 +53,28 @@ defmodule CraftplanWeb.ManageCustomersLiveTest do
     end
 
     @tag role: :staff
+    test "renders details tab when billing_address is nil (imported customer)", %{conn: conn} do
+      # Bottle-imported customers have a shipping_address but no billing_address.
+      c =
+        Customer
+        |> Ash.Changeset.for_create(:create, %{
+          type: :individual,
+          first_name: "Imported",
+          last_name: "Buyer",
+          email: "imported+#{System.unique_integer([:positive])}@local",
+          shipping_address: %{street: "1 St", city: "DC", country: "US"}
+        })
+        |> Ash.create!()
+
+      assert is_nil(c.billing_address)
+
+      {:ok, view, _html} = live(conn, ~p"/manage/customers/#{c.reference}")
+      assert render(view) =~ "Imported"
+      assert render(view) =~ "Billing Address"
+      assert render(view) =~ "Shipping Address"
+    end
+
+    @tag role: :staff
     test "renders orders and statistics tabs", %{conn: conn} do
       c = create_customer!()
 


### PR DESCRIPTION
## Problem

A customer can have a `shipping_address` but no `billing_address` (or neither) —
common for customers created via import or the API. The customer show page then
crashes:

    (KeyError) key :full_address not found in: nil

because the template renders `@customer.billing_address.full_address` without a
nil check.

## Fix

Guard both address fields with the `&&` idiom already used on the order invoice
page:

    {@customer.billing_address && @customer.billing_address.full_address}
    {@customer.shipping_address && @customer.shipping_address.full_address}

A new test covers the nil-billing-address case (customer with only a
`shipping_address`) and asserts the show page renders without error.

## Notes

No migrations or schema changes. The LiveView render guard is risk-free.
Developed/tested on a fork (Elixir 1.18); upstream CI on 1.20 to confirm.
